### PR TITLE
Per-user Kroger (Firestore), disconnect, AI chat titles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ GEMINI_API_KEY=
 GEMINI_MODEL=gemini-2.5-flash
 
 YOUTUBE_API_KEY=
+# Optional but recommended: public-video transcript fetches via Supadata native captions.
+# Keeps transcript retrieval working when direct YouTube transcript scraping is blocked.
+SUPADATA_API_KEY=
 
 KROGER_CLIENT_ID=
 KROGER_CLIENT_SECRET=

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,7 +18,7 @@ At a high level, the product promise is:
 There are three runtime services:
 
 - `web`: Next.js App Router app and Gemini agent host
-- `youtube-mcp`: Python MCP server for video search and transcript retrieval
+- `youtube-mcp`: Python MCP server for video search, transcript probing, and native-caption retrieval
 - `kroger-mcp`: Python MCP server for Kroger search, OAuth session state, and cart writes
 
 The browser only talks to `web`. `web` is the only public application surface the user needs. The MCP services are backend-only dependencies.
@@ -78,7 +78,8 @@ flowchart LR
     W --> YM["youtube-mcp"]
     W --> KM["kroger-mcp"]
     YM --> Y["YouTube Data API"]
-    YM --> T["Public caption / transcript access"]
+    YM --> S["Supadata Transcript API (native only)"]
+    YM --> T["Direct transcript probe / fallback"]
     KM --> K["Kroger APIs"]
 ```
 
@@ -140,13 +141,16 @@ This service handles:
 - YouTube search normalization
 - video candidate scoring
 - transcript probing
-- transcript retrieval
+- native transcript retrieval for the selected video
+- honest transcript status mapping (`available`, `unavailable`, `blocked`, `error`)
 - metadata packaging into MCP tool responses
 
 Important design choice:
 
 - CraveCart does not transcribe audio itself
-- it only uses public transcript access when available
+- it only uses existing captions; it does not ask Supadata to generate AI transcripts
+- it keeps search-time transcript probing cheap and local so every candidate does not consume transcript-provider credits
+- it prefers Supadata for the final selected-video fetch because direct transcript scraping is often blocked from server or cloud IPs
 - if none of the first five likely candidates expose a transcript, the system falls back to the most relevant candidate and later infers from title + description
 
 ### 4.3 `kroger-mcp`
@@ -267,6 +271,7 @@ It checks:
 - Gemini key present
 - YouTube key present
 - YouTube MCP `/health`
+- whether `youtube-mcp` reports `supadataConfigured`
 - Kroger MCP `/health`
 - whether Kroger API credentials are present in the web service env
 - whether **Firebase Admin** is configured (`firebaseConfigured`)
@@ -585,14 +590,25 @@ CraveCart does not generate transcripts itself.
 
 It relies on:
 
-- `youtube-transcript-api`
-- public subtitle access for manual or auto-generated English captions
+- `youtube-transcript-api` for low-cost transcript probing during candidate ranking
+- Supadata `/v1/transcript` with `mode=native` for selected-video retrieval
+- direct public subtitle access only as a last-resort fallback when Supadata has a transient provider failure
 
-If transcript retrieval works:
+The selected-video fetch flow is:
 
-- the transcript is cleaned and returned
+1. try Supadata in `mode=native`
+2. if Supadata returns a transcript directly, clean it and return it
+3. if Supadata returns an async job, poll until it completes or fails
+4. if Supadata says the transcript is unavailable, report that honestly and stop
+5. if Supadata transiently fails or rate-limits, try direct `youtube-transcript-api`
+6. if both paths fail, return an honest `blocked` or `error` status instead of claiming there is no transcript
 
-If it fails:
+Important constraint:
+
+- CraveCart does not call Supadata `mode=auto` or `mode=generate`
+- if YouTube already has captions, the app should use the native caption track rather than an AI-regenerated transcript
+
+If transcript retrieval still fails:
 
 - the selected video is still returned
 - the downstream system may use title + description inference
@@ -604,6 +620,7 @@ If it fails:
 
 - video metadata
 - transcript availability
+- transcript status (`available`, `unavailable`, `blocked`, `error`)
 - transcript text when available
 - transcript message when unavailable
 
@@ -875,6 +892,7 @@ Important envs:
 - `GEMINI_API_KEY`
 - `GEMINI_MODEL`
 - `YOUTUBE_API_KEY`
+- `SUPADATA_API_KEY` — recommended; mounted into `youtube-mcp` for native public-caption retrieval
 - `KROGER_CLIENT_ID`
 - `KROGER_CLIENT_SECRET`
 - `KROGER_REDIRECT_URI`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The browser only talks to the Next.js app. **Firebase** handles email/password i
 - `GEMINI_API_KEY`
 - `GEMINI_MODEL` default `gemini-2.5-flash`
 - `YOUTUBE_API_KEY`
+- `SUPADATA_API_KEY` optional but recommended for public-video transcript retrieval
 - `KROGER_CLIENT_ID`
 - `KROGER_CLIENT_SECRET`
 - `KROGER_REDIRECT_URI`
@@ -58,7 +59,7 @@ Optional local overrides:
 ## Setup
 
 1. Copy `.env.example` to `.env`.
-2. Fill in Gemini, YouTube, and Kroger values (including `KROGER_LOCATION_ID` for store-scoped search).
+2. Fill in Gemini, YouTube, and Kroger values (including `KROGER_LOCATION_ID` for store-scoped search). Set `SUPADATA_API_KEY` too if you want reliable native-caption retrieval when direct transcript scraping is blocked.
 3. Ensure the Kroger developer console lists a redirect URI that exactly matches `KROGER_REDIRECT_URI`.
 
 ## Run Locally
@@ -171,3 +172,4 @@ Covered areas:
 - Product matching is heuristic.
 - Signed-in chat history is stored in Firebase Firestore (`cravecart_user_chats`); anonymous/local-only remnants may still migrate from `localStorage` once after login.
 - The agent is intentionally domain-focused and will redirect unrelated prompts back toward food videos and grocery tasks.
+- Supadata transcript fetches run in `mode=native` only, so the app uses existing captions and does not silently switch to AI-generated transcripts.

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import { setFirebaseSessionCookieFromIdToken } from "@/lib/server/auth/firebaseSessionCookie"
 import { firebaseAdminConfigured } from "@/lib/server/firebase/admin"
+import { syncKrogerBrowserSessionForUser } from "@/lib/server/krogerSessionSync"
 
 export const runtime = "nodejs"
 
@@ -23,7 +24,8 @@ export async function POST(request: Request) {
   }
 
   try {
-    await setFirebaseSessionCookieFromIdToken(parsed.idToken)
+    const { uid } = await setFirebaseSessionCookieFromIdToken(parsed.idToken)
+    await syncKrogerBrowserSessionForUser(uid)
     return NextResponse.json({ ok: true as const })
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Session failed."

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { runAgentTurn } from "@/lib/agent/runAgentTurn"
 import { chatRequestSchema } from "@/lib/agent/schemas"
 import { getSessionUser } from "@/lib/server/auth/getSessionUser"
 import { ensureSessionId } from "@/lib/kroger/session"
+import { syncKrogerBrowserSessionForUser } from "@/lib/server/krogerSessionSync"
 
 export const runtime = "nodejs"
 
@@ -33,6 +34,7 @@ export async function POST(request: Request) {
     )
   }
 
+  await syncKrogerBrowserSessionForUser(authedUser.id)
   const sessionId = await ensureSessionId()
 
   const stream = new ReadableStream({

--- a/app/api/chat/session-title/route.ts
+++ b/app/api/chat/session-title/route.ts
@@ -2,27 +2,21 @@ import { NextResponse } from "next/server"
 import { z } from "zod"
 
 import { extractResponseText, getGeminiClient } from "@/lib/agent/gemini"
+import {
+  fallbackChatTitleFromFirstMessage,
+  normalizeGeminiChatTitle,
+} from "@/lib/chat/sessionTitle"
 import { getGeminiModel, isGeminiConfigured } from "@/lib/env"
 import { getSessionUser } from "@/lib/server/auth/getSessionUser"
 
 export const runtime = "nodejs"
 
 const bodySchema = z.object({
-  firstMessage: z.string().min(1).max(8000),
+  firstMessage: z.preprocess(
+    (v) => (typeof v === "string" ? v.trim() : v),
+    z.string().min(1).max(8000),
+  ),
 })
-
-function fallbackTitle(raw: string): string {
-  const t = raw.replace(/\s+/g, " ").trim()
-  if (!t) return "New chat"
-  return t.length > 48 ? `${t.slice(0, 45)}…` : t
-}
-
-function normalizeTitle(raw: string | undefined, fallbackFromUser: string): string {
-  if (!raw) return fallbackTitle(fallbackFromUser)
-  const oneLine = raw.replace(/\s+/g, " ").trim().replace(/^["']|["']$/g, "")
-  if (!oneLine) return fallbackTitle(fallbackFromUser)
-  return oneLine.length > 56 ? `${oneLine.slice(0, 53)}…` : oneLine
-}
 
 export async function POST(request: Request) {
   const user = await getSessionUser()
@@ -38,7 +32,7 @@ export async function POST(request: Request) {
   }
 
   if (!isGeminiConfigured()) {
-    return NextResponse.json({ title: fallbackTitle(parsed.firstMessage) })
+    return NextResponse.json({ title: fallbackChatTitleFromFirstMessage(parsed.firstMessage) })
   }
 
   try {
@@ -58,8 +52,8 @@ export async function POST(request: Request) {
     })
 
     const text = extractResponseText(response)
-    return NextResponse.json({ title: normalizeTitle(text, parsed.firstMessage) })
+    return NextResponse.json({ title: normalizeGeminiChatTitle(text, parsed.firstMessage) })
   } catch {
-    return NextResponse.json({ title: fallbackTitle(parsed.firstMessage) })
+    return NextResponse.json({ title: fallbackChatTitleFromFirstMessage(parsed.firstMessage) })
   }
 }

--- a/app/api/chat/session-title/route.ts
+++ b/app/api/chat/session-title/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server"
+import { z } from "zod"
+
+import { extractResponseText, getGeminiClient } from "@/lib/agent/gemini"
+import { getGeminiModel, isGeminiConfigured } from "@/lib/env"
+import { getSessionUser } from "@/lib/server/auth/getSessionUser"
+
+export const runtime = "nodejs"
+
+const bodySchema = z.object({
+  firstMessage: z.string().min(1).max(8000),
+})
+
+function fallbackTitle(raw: string): string {
+  const t = raw.replace(/\s+/g, " ").trim()
+  if (!t) return "New chat"
+  return t.length > 48 ? `${t.slice(0, 45)}…` : t
+}
+
+function normalizeTitle(raw: string | undefined, fallbackFromUser: string): string {
+  if (!raw) return fallbackTitle(fallbackFromUser)
+  const oneLine = raw.replace(/\s+/g, " ").trim().replace(/^["']|["']$/g, "")
+  if (!oneLine) return fallbackTitle(fallbackFromUser)
+  return oneLine.length > 56 ? `${oneLine.slice(0, 53)}…` : oneLine
+}
+
+export async function POST(request: Request) {
+  const user = await getSessionUser()
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 })
+  }
+
+  let parsed: z.infer<typeof bodySchema>
+  try {
+    parsed = bodySchema.parse(await request.json())
+  } catch {
+    return NextResponse.json({ error: "Invalid request." }, { status: 400 })
+  }
+
+  if (!isGeminiConfigured()) {
+    return NextResponse.json({ title: fallbackTitle(parsed.firstMessage) })
+  }
+
+  try {
+    const client = getGeminiClient()
+    const prompt = [
+      "You title chat threads for a grocery and recipe assistant (CraveCart).",
+      "Reply with ONLY a short thread title: 3 to 8 words, no quotation marks, no trailing punctuation flourish.",
+      "Focus on dish, craving, or shopping intent.",
+      "",
+      `User first message:\n${parsed.firstMessage}`,
+    ].join("\n")
+
+    const response = await client.models.generateContent({
+      model: getGeminiModel(),
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
+      config: { maxOutputTokens: 48 },
+    })
+
+    const text = extractResponseText(response)
+    return NextResponse.json({ title: normalizeTitle(text, parsed.firstMessage) })
+  } catch {
+    return NextResponse.json({ title: fallbackTitle(parsed.firstMessage) })
+  }
+}

--- a/app/api/crave/route.ts
+++ b/app/api/crave/route.ts
@@ -3,6 +3,7 @@ import { handleCraveRequest } from "@/lib/api/handleCraveRequest"
 import { craveRequestSchema } from "@/lib/llm/schemas"
 import { getSessionUser } from "@/lib/server/auth/getSessionUser"
 import { ensureSessionId } from "@/lib/kroger/session"
+import { syncKrogerBrowserSessionForUser } from "@/lib/server/krogerSessionSync"
 
 export async function POST(request: Request) {
   const user = await getSessionUser()
@@ -12,6 +13,7 @@ export async function POST(request: Request) {
 
   try {
     const payload = craveRequestSchema.parse(await request.json())
+    await syncKrogerBrowserSessionForUser(user.id)
     const sessionId = await ensureSessionId()
     const response = await handleCraveRequest(payload, sessionId)
     return NextResponse.json(response)

--- a/app/api/kroger/auth/start/route.ts
+++ b/app/api/kroger/auth/start/route.ts
@@ -1,9 +1,17 @@
 import { NextResponse } from "next/server"
 import { KrogerClient } from "@/lib/kroger/KrogerClient"
 import { ensureSessionId } from "@/lib/kroger/session"
+import { getSessionUser } from "@/lib/server/auth/getSessionUser"
+import { syncKrogerBrowserSessionForUser } from "@/lib/server/krogerSessionSync"
 
 export async function POST() {
+  const user = await getSessionUser()
+  if (!user) {
+    return NextResponse.json({ error: "Sign in to connect Kroger." }, { status: 401 })
+  }
+
   try {
+    await syncKrogerBrowserSessionForUser(user.id)
     const sessionId = await ensureSessionId()
     const client = new KrogerClient({ sessionId })
     const authUrl = await client.getAuthorizationUrl()

--- a/app/api/kroger/disconnect/route.ts
+++ b/app/api/kroger/disconnect/route.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from "node:crypto"
+
+import { NextResponse } from "next/server"
+
+import { setKrogerSessionCookie } from "@/lib/kroger/session"
+import { KrogerClient } from "@/lib/kroger/KrogerClient"
+import { getSessionUser } from "@/lib/server/auth/getSessionUser"
+import { setKrogerMcpSessionId } from "@/lib/server/krogerUserPrefs"
+import { syncKrogerBrowserSessionForUser } from "@/lib/server/krogerSessionSync"
+
+export const runtime = "nodejs"
+
+export async function POST() {
+  const user = await getSessionUser()
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 })
+  }
+
+  const prior = await syncKrogerBrowserSessionForUser(user.id)
+  try {
+    const client = new KrogerClient({ sessionId: prior })
+    await client.clearRemoteSession()
+  } catch {
+    // Continue: rotate Firestore + cookie so the next connect is a fresh Kroger login.
+  }
+
+  const nextId = randomUUID()
+  await setKrogerMcpSessionId(user.id, nextId)
+  await setKrogerSessionCookie(nextId)
+
+  return NextResponse.json({ ok: true as const })
+}

--- a/app/api/kroger/status/route.ts
+++ b/app/api/kroger/status/route.ts
@@ -12,7 +12,6 @@ export async function GET() {
     return NextResponse.json({
       authenticated: false,
       configured: false,
-      mockMode: false,
       needsFirebaseAuth: true as const,
     })
   }
@@ -24,8 +23,6 @@ export async function GET() {
   return NextResponse.json({
     authenticated: Boolean(st.authenticated),
     configured: Boolean(st.configured),
-    /** Kroger API not configured — dev / missing secrets; UI may still allow limited flows. */
-    mockMode: !st.configured,
     needsFirebaseAuth: false as const,
   })
 }

--- a/app/api/kroger/status/route.ts
+++ b/app/api/kroger/status/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+
+import { KrogerClient } from "@/lib/kroger/KrogerClient"
+import { getSessionUser } from "@/lib/server/auth/getSessionUser"
+import { syncKrogerBrowserSessionForUser } from "@/lib/server/krogerSessionSync"
+
+export const runtime = "nodejs"
+
+export async function GET() {
+  const user = await getSessionUser()
+  if (!user) {
+    return NextResponse.json({
+      authenticated: false,
+      configured: false,
+      mockMode: false,
+      needsFirebaseAuth: true as const,
+    })
+  }
+
+  const sessionId = await syncKrogerBrowserSessionForUser(user.id)
+  const client = new KrogerClient({ sessionId })
+  const st = await client.getSessionOAuthStatus()
+
+  return NextResponse.json({
+    authenticated: Boolean(st.authenticated),
+    configured: Boolean(st.configured),
+    /** Kroger API not configured — dev / missing secrets; UI may still allow limited flows. */
+    mockMode: !st.configured,
+    needsFirebaseAuth: false as const,
+  })
+}

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -5,7 +5,12 @@ import Link from "next/link"
 import { useSearchParams } from "next/navigation"
 import { confirmPasswordReset, getAuth } from "firebase/auth"
 import { Eye, EyeOff, ShoppingCart } from "lucide-react"
-import { fetchFirebaseBrowserConfig, getFirebaseBrowserApp, mapFirebaseAuthError } from "@/lib/firebase/clientAuth"
+import {
+  fetchFirebaseBrowserConfig,
+  FIREBASE_RESET_OUTLOOK_SAFELINKS_HINT,
+  getFirebaseBrowserApp,
+  mapFirebaseAuthError,
+} from "@/lib/firebase/clientAuth"
 import { cn } from "@/lib/utils"
 
 function ResetPasswordForm() {
@@ -91,6 +96,7 @@ function ResetPasswordForm() {
           Request a password reset from the CraveCart sign-in screen. This page must be opened from the Firebase email
           link (includes <span className="font-mono text-[12px] text-white/45">oobCode</span> in the URL).
         </p>
+        <p className="text-[12px] leading-relaxed text-white/42">{FIREBASE_RESET_OUTLOOK_SAFELINKS_HINT}</p>
         <Link
           href="/"
           className="inline-flex w-full items-center justify-center rounded-full border border-white/15 py-3 text-[13px] font-medium text-white/85 transition-colors hover:bg-white/8"

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -48,7 +48,7 @@ function ResetPasswordForm() {
         const auth = getAuth(getFirebaseBrowserApp(cfg))
         await confirmPasswordReset(auth, oobCode, pw)
       } catch (err) {
-        setError(mapFirebaseAuthError(err))
+        setError(mapFirebaseAuthError(err, "passwordReset"))
         return
       }
       setDone(true)

--- a/app/globals.css
+++ b/app/globals.css
@@ -122,6 +122,45 @@
   to   { opacity: 1; transform: translateY(0);    }
 }
 
+@keyframes cinematic-drift {
+  0%, 100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.35; }
+  50% { transform: translate3d(0, -18px, 0) scale(1.08); opacity: 0.55; }
+}
+
+@keyframes spotlight-sweep {
+  0% { transform: translateX(-120%) skewX(-18deg); opacity: 0; }
+  20% { opacity: 0.35; }
+  50% { opacity: 0.6; }
+  100% { transform: translateX(240%) skewX(-18deg); opacity: 0; }
+}
+
+@keyframes card-pop-in {
+  from { opacity: 0; transform: translateY(14px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes orbit-slow {
+  from { transform: rotate(0deg) translateX(8px) rotate(0deg); }
+  to { transform: rotate(360deg) translateX(8px) rotate(-360deg); }
+}
+
+@keyframes shimmer-scan {
+  0% { transform: translateX(-130%); opacity: 0; }
+  35% { opacity: 0.4; }
+  100% { transform: translateX(220%); opacity: 0; }
+}
+
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 0 rgba(245, 177, 80, 0); }
+  50% { box-shadow: 0 0 42px rgba(245, 177, 80, 0.18); }
+}
+
+/* Softer nudge for “Connect Kroger” when user skipped the prompt */
+@keyframes kroger-connect-nudge {
+  0%, 100% { transform: translateX(0); box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.18); }
+  50% { transform: translateX(-3px); box-shadow: 0 0 22px 2px rgba(251, 191, 36, 0.14); }
+}
+
 /* ── Utility: hide scrollbar while keeping scroll behaviour ─────────── */
 .scrollbar-none {
   -ms-overflow-style: none;
@@ -129,4 +168,66 @@
 }
 .scrollbar-none::-webkit-scrollbar {
   display: none;
+}
+
+/* ── Shared cinematic utilities ──────────────────────────────────────── */
+.surface-glass {
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  background: color-mix(in oklab, var(--color-card) 78%, transparent);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 20px 42px rgba(0, 0, 0, 0.35);
+}
+
+.surface-glass-soft {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(255, 255, 255, 0.035);
+  backdrop-filter: blur(10px);
+}
+
+.cinematic-divider {
+  position: relative;
+}
+
+.cinematic-divider::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(to right, transparent, rgba(245, 177, 80, 0.5), transparent);
+}
+
+.reveal-up {
+  animation: fade-in-up 420ms ease-out both;
+}
+
+.interactive-shimmer {
+  position: relative;
+  overflow: hidden;
+}
+
+.interactive-shimmer::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 -20%;
+  width: 28%;
+  background: linear-gradient(to right, transparent, rgba(255, 255, 255, 0.2), transparent);
+  opacity: 0;
+}
+
+.interactive-shimmer:hover::after {
+  animation: shimmer-scan 1000ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.kroger-connect-nudge {
+  animation: kroger-connect-nudge 2.4s ease-in-out infinite;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -49,12 +49,6 @@ const EXAMPLES = [
   { icon: Sparkles, text: "Find a good chicken alfredo video and buy the groceries" },
 ] as const
 
-const FEATURE_PILLS = [
-  "YouTube search & transcripts",
-  "Kroger product matching",
-  "Live cart actions",
-]
-
 interface UiMessage {
   id: string
   role: "user" | "assistant"
@@ -87,7 +81,6 @@ export default function HomePage() {
   const [user, setUser] = useState<User | null>(null)
   const [userLoaded, setUserLoaded] = useState(false)
   const [krogerConnected, setKrogerConnected] = useState(false)
-  const [krogerIsMock, setKrogerIsMock] = useState(false)
   const [sessions, setSessions] = useState<ChatSession[]>([])
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null)
   const [messages, setMessages] = useState<UiMessage[]>([])
@@ -114,7 +107,7 @@ export default function HomePage() {
   useEffect(() => {
     if (!userLoaded || typeof window === "undefined") return
     setKrogerPromptDismissed(isKrogerConnectPromptDismissed(window.sessionStorage))
-  }, [userLoaded, user, krogerConnected, krogerIsMock])
+  }, [userLoaded, user, krogerConnected])
 
   useEffect(() => {
     if (!userLoaded || typeof window === "undefined") return
@@ -138,10 +131,10 @@ export default function HomePage() {
     ) {
       return
     }
-    if (krogerConnected || krogerIsMock) return
+    if (krogerConnected) return
     if (isKrogerConnectPromptDismissed(window.sessionStorage)) return
     setKrogerConnectPromptOpen(true)
-  }, [userLoaded, user, krogerConnected, krogerIsMock])
+  }, [userLoaded, user, krogerConnected])
 
   function handleOnboardingOpenChange(open: boolean) {
     setOnboardingOpen(open)
@@ -149,7 +142,7 @@ export default function HomePage() {
       markFirstVisitTourSeen(window.localStorage)
       // After tour, eligible users see Kroger prompt on next effect tick — open here if onboarding blocked it
       queueMicrotask(() => {
-        if (!user || krogerConnected || krogerIsMock) return
+        if (!user || krogerConnected) return
         if (isKrogerConnectPromptDismissed(sessionStorage)) return
         setKrogerConnectPromptOpen(true)
       })
@@ -162,30 +155,16 @@ export default function HomePage() {
       if (!r.ok) return
       const d = (await r.json()) as {
         authenticated?: boolean
-        mockMode?: boolean
         needsFirebaseAuth?: boolean
       }
       if (d.needsFirebaseAuth) return
-
-      if (d.mockMode) {
-        clearKrogerConnectRedirectPending()
-        setKrogerIsMock(true)
-        setKrogerConnected(true)
-        localStorage.setItem("cravecart_kroger_connected", "1")
-        localStorage.setItem("cravecart_kroger_mock", "1")
-        return
-      }
-
-      setKrogerIsMock(false)
       if (d.authenticated) {
         clearKrogerConnectRedirectPending()
         setKrogerConnected(true)
         localStorage.setItem("cravecart_kroger_connected", "1")
-        localStorage.removeItem("cravecart_kroger_mock")
       } else {
         setKrogerConnected(false)
         localStorage.removeItem("cravecart_kroger_connected")
-        localStorage.removeItem("cravecart_kroger_mock")
       }
     } catch {
       // Leave prior UI state on network errors.
@@ -382,9 +361,7 @@ export default function HomePage() {
       credentials: "same-origin",
     })
     setKrogerConnected(false)
-    setKrogerIsMock(false)
     localStorage.removeItem("cravecart_kroger_connected")
-    localStorage.removeItem("cravecart_kroger_mock")
     clearKrogerConnectRedirectPending()
     if (typeof window !== "undefined") {
       clearKrogerConnectPromptDismissed(window.sessionStorage)
@@ -628,7 +605,6 @@ export default function HomePage() {
     <OnboardingOverlay
       open={onboardingOpen}
       onOpenChange={handleOnboardingOpenChange}
-      onKrogerMockConnected={handleKrogerConnected}
       signedIn={Boolean(user)}
     />
   )
@@ -702,9 +678,7 @@ export default function HomePage() {
           {/* Kroger button */}
           <KrogerConnectButton
             isConnected={krogerConnected}
-            isMock={krogerIsMock}
-            attentionNudge={krogerPromptDismissed && !krogerConnected && !krogerIsMock}
-            onConnected={handleKrogerConnected}
+            attentionNudge={krogerPromptDismissed && !krogerConnected}
             onDisconnected={handleKrogerDisconnected}
           />
         </header>
@@ -721,54 +695,37 @@ export default function HomePage() {
               >
                 {/* Welcome screen */}
                 {messages.length === 0 && (
-                  <div className="flex min-h-full flex-col gap-4 pb-2">
-                    {/* Cinematic hero fill — tagline + food floaters + category chips */}
-                    <div className="flex min-h-0 flex-1 items-center justify-center py-2">
+                  <div className="flex min-h-full flex-col gap-3 pb-3">
+                    {/* Masthead — tagline + cravings */}
+                    <div className="flex min-h-0 shrink-0 items-center justify-center pt-2 md:pt-3">
                       <WelcomeHero onSelectCategory={submitPrompt} agentChatEnabled />
                     </div>
-                    <article className="w-full">
 
-                      {/* Hero card */}
-                      <div className="surface-glass interactive-shimmer relative overflow-hidden rounded-[28px] px-6 py-6">
-                        {/* Top gradient line */}
+                    <article className="w-full space-y-3">
+                      {/* Primary prompt card */}
+                      <div className="surface-glass interactive-shimmer relative overflow-hidden rounded-[24px] px-5 py-5 sm:rounded-[28px] sm:px-6 sm:py-6">
                         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/35 to-transparent" />
 
-                        <div className="flex items-start gap-4">
-                          <div className="relative mt-0.5 shrink-0">
-                            <div className="absolute inset-0 rounded-xl bg-primary/20 blur-md" />
-                            <div className="relative flex h-10 w-10 items-center justify-center rounded-xl border border-primary/30 bg-gradient-to-br from-primary/25 to-primary/8">
-                              <ShoppingCart className="h-5 w-5 text-primary" />
+                        <div className="flex gap-4">
+                          <div className="relative mt-1 shrink-0">
+                            <div className="absolute inset-0 rounded-xl bg-primary/18 blur-lg" />
+                            <div className="relative flex h-10 w-10 items-center justify-center rounded-xl border border-primary/28 bg-gradient-to-br from-primary/22 to-primary/6">
+                              <ShoppingCart className="h-5 w-5 text-primary" aria-hidden />
                             </div>
                           </div>
                           <div className="min-w-0 flex-1">
-                            <p className="text-[10px] uppercase tracking-[0.22em] text-white/35">
-                              CraveCart · AI Agent
-                            </p>
-                            <h1 className="mt-2 text-2xl font-semibold leading-snug tracking-tight text-white md:text-[1.65rem]">
+                            <h1 className="text-xl font-semibold leading-snug tracking-tight text-white sm:text-[1.375rem]">
                               Hey {firstName}, what are you craving?
                             </h1>
-                            <p className="mt-2 text-[14px] leading-relaxed text-white/55">
-                              Tell me a dish, a video, or just "buy groceries" — I'll handle the rest
-                              across YouTube and Kroger in real time.
+                            <p className="mt-2 max-w-xl text-[13px] leading-relaxed text-white/52 sm:text-[14px]">
+                              One conversation for video, groceries, and (when Kroger&apos;s linked) cart — start with anything below or type your own.
                             </p>
                           </div>
                         </div>
-
-                        {/* Feature pills */}
-                        <div className="mt-5 flex flex-wrap gap-2">
-                          {FEATURE_PILLS.map((pill) => (
-                            <span
-                              key={pill}
-                              className="rounded-full border border-white/[0.08] bg-white/[0.05] px-3 py-1 text-[11px] text-white/45"
-                            >
-                              {pill}
-                            </span>
-                          ))}
-                        </div>
                       </div>
 
-                      {/* Suggestion chips */}
-                      <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      {/* Starter prompts */}
+                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                         {EXAMPLES.map(({ icon: Icon, text }) => (
                           <button
                             key={text}
@@ -885,12 +842,12 @@ export default function HomePage() {
                   onSubmit={submitPrompt}
                   isLoading={isSending}
                   placeholder={
-                    krogerConnected || krogerIsMock
+                    krogerConnected
                       ? "Ask for a recipe, groceries, or both…"
                       : "Chat works now — link Kroger (top-right) when you want cart checkout…"
                   }
                 />
-                {!krogerConnected && !krogerIsMock ? (
+                {!krogerConnected ? (
                   <p className="mt-2 text-center text-[11px] text-white/32">
                     Without Kroger, the assistant can browse ideas and prep lists — reconnect when you&apos;re ready to match products and carts.
                   </p>
@@ -906,7 +863,6 @@ export default function HomePage() {
       <ConnectKrogerPromptDialog
         open={krogerConnectPromptOpen}
         onOpenChange={setKrogerConnectPromptOpen}
-        onConnected={handleKrogerConnected}
         afterDismissPersist={() => setKrogerPromptDismissed(true)}
       />
     {onboardingOverlay}
@@ -946,7 +902,10 @@ function deriveVideoArtifact(trace: ToolTraceEntry): VideoArtifact | null {
   const video = output.video as Record<string, unknown> | undefined
   if (!video || typeof video.title !== "string" || typeof video.url !== "string" || typeof video.channel !== "string") return null
   const recipeSource =
-    output.recipeSource === "youtube_transcript" || output.recipeSource === "fallback_recipe" || output.recipeSource === "none"
+    output.recipeSource === "youtube_transcript" ||
+    output.recipeSource === "fallback_recipe" ||
+    output.recipeSource === "video_metadata" ||
+    output.recipeSource === "none"
       ? output.recipeSource : "none"
   return {
     kind: "video",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -629,6 +629,7 @@ export default function HomePage() {
       open={onboardingOpen}
       onOpenChange={handleOnboardingOpenChange}
       onKrogerMockConnected={handleKrogerConnected}
+      signedIn={Boolean(user)}
     />
   )
 
@@ -951,6 +952,14 @@ function deriveVideoArtifact(trace: ToolTraceEntry): VideoArtifact | null {
     kind: "video",
     video: { title: video.title, url: video.url, channel: video.channel },
     transcriptAvailable: Boolean(output.transcriptAvailable),
+    transcriptStatus:
+      output.transcriptStatus === "available" ||
+      output.transcriptStatus === "unavailable" ||
+      output.transcriptStatus === "blocked" ||
+      output.transcriptStatus === "error"
+        ? output.transcriptStatus
+        : undefined,
+    transcriptMessage: typeof output.transcriptMessage === "string" ? output.transcriptMessage : undefined,
     recipeSource,
     summary:
       typeof output.recipeText === "string" ? output.recipeText.slice(0, 280)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,18 +81,56 @@ export default function HomePage() {
   const messagesViewportRef = useRef<HTMLDivElement | null>(null)
   const messagesEndRef = useRef<HTMLDivElement | null>(null)
   const latestMessagesRef = useRef<UiMessage[]>([])
+  const sessionsRef = useRef<ChatSession[]>([])
+  /** Stable sidebar titles — AI-named for new chats, or loaded from Firestore */
+  const resolvedChatTitleRef = useRef<Map<string, string>>(new Map())
+  const aiTitleRequestedRef = useRef<Set<string>>(new Set())
 
   useEffect(() => {
-    const pending = localStorage.getItem("cravecart_kroger_pending")
-    if (pending) {
-      localStorage.removeItem("cravecart_kroger_pending")
-      localStorage.setItem("cravecart_kroger_connected", "1")
-      setKrogerConnected(true)
-    } else if (localStorage.getItem("cravecart_kroger_connected")) {
-      setKrogerConnected(true)
-      if (localStorage.getItem("cravecart_kroger_mock")) setKrogerIsMock(true)
-    }
+    sessionsRef.current = sessions
+  }, [sessions])
 
+  async function refreshKrogerFromServer() {
+    try {
+      const pending = localStorage.getItem("cravecart_kroger_pending")
+      if (pending) {
+        localStorage.removeItem("cravecart_kroger_pending")
+        localStorage.setItem("cravecart_kroger_connected", "1")
+      }
+
+      const r = await fetch("/api/kroger/status", { credentials: "same-origin" })
+      if (!r.ok) return
+      const d = (await r.json()) as {
+        authenticated?: boolean
+        mockMode?: boolean
+        needsFirebaseAuth?: boolean
+      }
+      if (d.needsFirebaseAuth) return
+
+      if (d.mockMode) {
+        setKrogerIsMock(true)
+        setKrogerConnected(true)
+        localStorage.setItem("cravecart_kroger_connected", "1")
+        localStorage.setItem("cravecart_kroger_mock", "1")
+        return
+      }
+
+      setKrogerIsMock(false)
+      if (d.authenticated) {
+        setKrogerConnected(true)
+        localStorage.setItem("cravecart_kroger_connected", "1")
+        localStorage.removeItem("cravecart_kroger_mock")
+      } else {
+        setKrogerConnected(false)
+        localStorage.removeItem("cravecart_kroger_connected")
+        localStorage.removeItem("cravecart_kroger_mock")
+      }
+    } catch {
+      // Leave prior UI state on network errors.
+    }
+  }
+
+  useEffect(() => {
     ;(async () => {
       try {
         const meRes = await fetch("/api/auth/me", { credentials: "same-origin" })
@@ -102,6 +140,7 @@ export default function HomePage() {
           setUser(authedUser)
           await loadSessionsForUser(authedUser.id)
           await migrateLocalHistoryIfNeeded()
+          await refreshKrogerFromServer()
         }
       } catch {
         // stay logged out — LoginScreen gates the app
@@ -109,18 +148,6 @@ export default function HomePage() {
         setUserLoaded(true)
       }
     })()
-
-    fetch("/api/kroger/auth/start", { method: "POST" })
-      .then((r) => r.json())
-      .then((data: { mockMode?: boolean }) => {
-        if (data.mockMode) {
-          setKrogerConnected(true)
-          setKrogerIsMock(true)
-          localStorage.setItem("cravecart_kroger_connected", "1")
-          localStorage.setItem("cravecart_kroger_mock", "1")
-        }
-      })
-      .catch(() => {})
   }, [])
 
   async function loadSessionsForUser(_userId: string) {
@@ -129,6 +156,9 @@ export default function HomePage() {
       if (!r.ok) return
       const data = (await r.json()) as { sessions?: ChatSession[] }
       const list = data.sessions ?? []
+      for (const s of list) {
+        if (s.title) resolvedChatTitleRef.current.set(s.id, s.title)
+      }
       setSessions(list)
 
       const last = sessionStorage.getItem("cravecart_active_session")
@@ -187,6 +217,9 @@ export default function HomePage() {
   }
 
   async function handleSelectSessionFromServer(id: string) {
+    const meta = sessions.find((s) => s.id === id)
+    if (meta?.title) resolvedChatTitleRef.current.set(id, meta.title)
+
     setActiveSessionId(id)
     setSidebarOpen(false)
     sessionStorage.setItem("cravecart_active_session", id)
@@ -252,6 +285,7 @@ export default function HomePage() {
     setUser({ id: next.id, name: next.name, email: next.email })
     void loadSessionsForUser(next.id)
     void migrateLocalHistoryIfNeeded()
+    void refreshKrogerFromServer()
   }
 
   async function handleLogout() {
@@ -271,6 +305,19 @@ export default function HomePage() {
   function handleKrogerConnected() {
     setKrogerConnected(true)
     localStorage.setItem("cravecart_kroger_connected", "1")
+    void refreshKrogerFromServer()
+  }
+
+  async function handleKrogerDisconnected() {
+    await fetch("/api/kroger/disconnect", {
+      method: "POST",
+      credentials: "same-origin",
+    })
+    setKrogerConnected(false)
+    setKrogerIsMock(false)
+    localStorage.removeItem("cravecart_kroger_connected")
+    localStorage.removeItem("cravecart_kroger_mock")
+    localStorage.removeItem("cravecart_kroger_pending")
   }
 
   function handleNewChat() {
@@ -315,6 +362,8 @@ export default function HomePage() {
   async function submitPrompt(prompt: string) {
     if (isSending || !krogerConnected) return
 
+    const isFirstUserTurn = messages.length === 0
+
     const userMessage = makeUserMessage(prompt)
     const assistantMessage = makeAssistantPlaceholder()
     const historyForRequest = [...messages, userMessage]
@@ -324,7 +373,6 @@ export default function HomePage() {
       setActiveSessionId(sessionId)
       sessionStorage.setItem("cravecart_active_session", sessionId)
     }
-    const sessionTitle = prompt.length > 42 ? prompt.slice(0, 42) + "…" : prompt
 
     updateMessages(() => [...historyForRequest, assistantMessage])
     setIsSending(true)
@@ -357,7 +405,39 @@ export default function HomePage() {
       }))
     } finally {
       setIsSending(false)
-      persistSession(sessionId, sessionTitle, latestMessagesRef.current)
+
+      const titleForSave = (() => {
+        const fromRef = resolvedChatTitleRef.current.get(sessionId)
+        if (fromRef) return fromRef
+        const fromSidebar = sessionsRef.current.find((s) => s.id === sessionId)?.title
+        if (fromSidebar) return fromSidebar
+        return isFirstUserTurn ? "New chat" : prompt.length > 48 ? `${prompt.slice(0, 45)}…` : prompt
+      })()
+
+      persistSession(sessionId, titleForSave, latestMessagesRef.current)
+
+      if (isFirstUserTurn && !aiTitleRequestedRef.current.has(sessionId)) {
+        aiTitleRequestedRef.current.add(sessionId)
+        void (async () => {
+          try {
+            const tr = await fetch("/api/chat/session-title", {
+              method: "POST",
+              credentials: "same-origin",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ firstMessage: prompt }),
+            })
+            if (!tr.ok) return
+            const body = (await tr.json()) as { title?: string }
+            const nextTitle = body.title?.trim()
+            if (!nextTitle) return
+            resolvedChatTitleRef.current.set(sessionId, nextTitle)
+            setSessions((prev) => prev.map((s) => (s.id === sessionId ? { ...s, title: nextTitle } : s)))
+            persistSession(sessionId, nextTitle, latestMessagesRef.current)
+          } catch {
+            aiTitleRequestedRef.current.delete(sessionId)
+          }
+        })()
+      }
     }
   }
 
@@ -495,6 +575,7 @@ export default function HomePage() {
             isConnected={krogerConnected}
             isMock={krogerIsMock}
             onConnected={handleKrogerConnected}
+            onDisconnected={handleKrogerDisconnected}
           />
         </header>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import {
   AlertCircle,
   ChevronRight,
+  CircleHelp,
   Flame,
   Loader2,
   Menu,
@@ -19,7 +20,9 @@ import { ChatInput } from "@/components/ChatInput"
 import { ChatMarkdown } from "@/components/ChatMarkdown"
 import { VideoResultCard } from "@/components/VideoResultCard"
 import { Button } from "@/components/ui/button"
+import { ConnectKrogerPromptDialog } from "@/components/ConnectKrogerPromptDialog"
 import { LoginScreen } from "@/components/LoginScreen"
+import { OnboardingOverlay } from "@/components/OnboardingOverlay"
 import { Sidebar, type ChatSession } from "@/components/Sidebar"
 import { KrogerConnectButton } from "@/components/KrogerConnectButton"
 import { buildChatMessagesForAgent, coerceReplayMessageContent } from "@/lib/chat/chatHistoryPayload"
@@ -28,6 +31,12 @@ import {
   pickFirstUserMessageForSessionTitle,
   resolvePersistedChatTitle,
 } from "@/lib/chat/sessionTitle"
+import { clearKrogerConnectRedirectPending } from "@/lib/kroger/clientStartConnect"
+import {
+  clearKrogerConnectPromptDismissed,
+  isKrogerConnectPromptDismissed,
+} from "@/lib/kroger/connectPromptSession"
+import { markFirstVisitTourSeen, shouldShowOnboardingAuto } from "@/lib/onboarding/state"
 import { cn } from "@/lib/utils"
 import { WelcomeHero } from "@/components/WelcomeHero"
 import type { AgentStreamEvent, CartArtifact, ToolTraceEntry, VideoArtifact } from "@/lib/types"
@@ -93,18 +102,62 @@ export default function HomePage() {
   const resolvedChatTitleRef = useRef<Map<string, string>>(new Map())
   const aiTitleRequestedRef = useRef<Set<string>>(new Set())
 
+  const [onboardingOpen, setOnboardingOpen] = useState(false)
+  const [krogerConnectPromptOpen, setKrogerConnectPromptOpen] = useState(false)
+  /** SessionStorage mirror for header “Connect Kroger” nudge pulse */
+  const [krogerPromptDismissed, setKrogerPromptDismissed] = useState(false)
+
   useEffect(() => {
     sessionsRef.current = sessions
   }, [sessions])
 
+  useEffect(() => {
+    if (!userLoaded || typeof window === "undefined") return
+    setKrogerPromptDismissed(isKrogerConnectPromptDismissed(window.sessionStorage))
+  }, [userLoaded, user, krogerConnected, krogerIsMock])
+
+  useEffect(() => {
+    if (!userLoaded || typeof window === "undefined") return
+    if (
+      shouldShowOnboardingAuto({
+        storage: window.localStorage,
+        cookie: document.cookie,
+      })
+    ) {
+      setOnboardingOpen(true)
+    }
+  }, [userLoaded])
+
+  useEffect(() => {
+    if (!userLoaded || !user || typeof window === "undefined") return
+    if (
+      shouldShowOnboardingAuto({
+        storage: window.localStorage,
+        cookie: document.cookie,
+      })
+    ) {
+      return
+    }
+    if (krogerConnected || krogerIsMock) return
+    if (isKrogerConnectPromptDismissed(window.sessionStorage)) return
+    setKrogerConnectPromptOpen(true)
+  }, [userLoaded, user, krogerConnected, krogerIsMock])
+
+  function handleOnboardingOpenChange(open: boolean) {
+    setOnboardingOpen(open)
+    if (!open && typeof window !== "undefined") {
+      markFirstVisitTourSeen(window.localStorage)
+      // After tour, eligible users see Kroger prompt on next effect tick — open here if onboarding blocked it
+      queueMicrotask(() => {
+        if (!user || krogerConnected || krogerIsMock) return
+        if (isKrogerConnectPromptDismissed(sessionStorage)) return
+        setKrogerConnectPromptOpen(true)
+      })
+    }
+  }
+
   async function refreshKrogerFromServer() {
     try {
-      const pending = localStorage.getItem("cravecart_kroger_pending")
-      if (pending) {
-        localStorage.removeItem("cravecart_kroger_pending")
-        localStorage.setItem("cravecart_kroger_connected", "1")
-      }
-
       const r = await fetch("/api/kroger/status", { credentials: "same-origin" })
       if (!r.ok) return
       const d = (await r.json()) as {
@@ -115,6 +168,7 @@ export default function HomePage() {
       if (d.needsFirebaseAuth) return
 
       if (d.mockMode) {
+        clearKrogerConnectRedirectPending()
         setKrogerIsMock(true)
         setKrogerConnected(true)
         localStorage.setItem("cravecart_kroger_connected", "1")
@@ -124,6 +178,7 @@ export default function HomePage() {
 
       setKrogerIsMock(false)
       if (d.authenticated) {
+        clearKrogerConnectRedirectPending()
         setKrogerConnected(true)
         localStorage.setItem("cravecart_kroger_connected", "1")
         localStorage.removeItem("cravecart_kroger_mock")
@@ -310,8 +365,14 @@ export default function HomePage() {
   }
 
   function handleKrogerConnected() {
+    clearKrogerConnectRedirectPending()
     setKrogerConnected(true)
     localStorage.setItem("cravecart_kroger_connected", "1")
+    if (typeof window !== "undefined") {
+      clearKrogerConnectPromptDismissed(window.sessionStorage)
+      setKrogerPromptDismissed(false)
+      setKrogerConnectPromptOpen(false)
+    }
     void refreshKrogerFromServer()
   }
 
@@ -324,7 +385,12 @@ export default function HomePage() {
     setKrogerIsMock(false)
     localStorage.removeItem("cravecart_kroger_connected")
     localStorage.removeItem("cravecart_kroger_mock")
-    localStorage.removeItem("cravecart_kroger_pending")
+    clearKrogerConnectRedirectPending()
+    if (typeof window !== "undefined") {
+      clearKrogerConnectPromptDismissed(window.sessionStorage)
+      setKrogerPromptDismissed(false)
+      setKrogerConnectPromptOpen(true)
+    }
   }
 
   function handleNewChat() {
@@ -367,7 +433,7 @@ export default function HomePage() {
   }
 
   async function submitPrompt(prompt: string) {
-    if (isSending || !krogerConnected) return
+    if (isSending) return
 
     const isFirstUserTurn = messages.length === 0
 
@@ -516,6 +582,11 @@ export default function HomePage() {
         })
         break
       case "needs_kroger_auth":
+        if (typeof window !== "undefined") {
+          clearKrogerConnectPromptDismissed(window.sessionStorage)
+          setKrogerPromptDismissed(false)
+          setKrogerConnectPromptOpen(true)
+        }
         updateAssistantMessage(assistantId, (c) => ({
           ...c,
           status: "idle",
@@ -553,12 +624,28 @@ export default function HomePage() {
 
   if (!userLoaded) return null
 
-  if (!user) return <LoginScreen onAuthed={handleAuthed} />
+  const onboardingOverlay = (
+    <OnboardingOverlay
+      open={onboardingOpen}
+      onOpenChange={handleOnboardingOpenChange}
+      onKrogerMockConnected={handleKrogerConnected}
+    />
+  )
+
+  if (!user) {
+    return (
+      <>
+        <LoginScreen onAuthed={handleAuthed} />
+        {onboardingOverlay}
+      </>
+    )
+  }
 
   const firstName = user.name.split(" ")[0]
 
   return (
-    <div className="relative z-10 flex h-screen overflow-hidden">
+    <>
+    <div className="relative z-10 flex h-screen overflow-hidden bg-[radial-gradient(circle_at_20%_0%,rgba(245,177,80,0.08),transparent_35%),radial-gradient(circle_at_90%_90%,rgba(56,189,248,0.07),transparent_30%)]">
       {/* Left sidebar */}
       <Sidebar
         sessions={sessions}
@@ -576,7 +663,7 @@ export default function HomePage() {
       <div className="flex min-w-0 flex-1 flex-col">
 
         {/* ── Header ── */}
-        <header className="flex items-center gap-3 border-b border-white/[0.07] bg-[oklch(0.13_0.02_248/0.5)] px-4 py-2.5 backdrop-blur-sm">
+        <header className="surface-glass-soft flex items-center gap-3 border-b border-white/[0.07] px-4 py-2.5">
           {/* Hamburger (mobile) */}
           <button
             onClick={() => setSidebarOpen(true)}
@@ -601,10 +688,21 @@ export default function HomePage() {
             </span>
           </div>
 
+          <button
+            type="button"
+            onClick={() => setOnboardingOpen(true)}
+            className="interactive-shimmer rounded-xl p-2 text-white/38 transition-colors hover:bg-white/8 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/45"
+            aria-label="Open product tour"
+            title="How CraveCart works"
+          >
+            <CircleHelp className="h-5 w-5" />
+          </button>
+
           {/* Kroger button */}
           <KrogerConnectButton
             isConnected={krogerConnected}
             isMock={krogerIsMock}
+            attentionNudge={krogerPromptDismissed && !krogerConnected && !krogerIsMock}
             onConnected={handleKrogerConnected}
             onDisconnected={handleKrogerDisconnected}
           />
@@ -612,7 +710,7 @@ export default function HomePage() {
 
         {/* ── Chat area ── */}
         <main className="flex min-h-0 flex-1 flex-col px-4 pb-3 pt-4 md:px-8">
-          <div className="mx-auto flex h-full w-full max-w-3xl flex-col">
+          <div className="mx-auto flex h-full w-full max-w-4xl flex-col">
             <section className="flex min-h-0 flex-1 flex-col">
 
               {/* Messages */}
@@ -625,15 +723,12 @@ export default function HomePage() {
                   <div className="flex min-h-full flex-col gap-4 pb-2">
                     {/* Cinematic hero fill — tagline + food floaters + category chips */}
                     <div className="flex min-h-0 flex-1 items-center justify-center py-2">
-                      <WelcomeHero
-                        onSelectCategory={submitPrompt}
-                        krogerConnected={krogerConnected}
-                      />
+                      <WelcomeHero onSelectCategory={submitPrompt} agentChatEnabled />
                     </div>
                     <article className="w-full">
 
                       {/* Hero card */}
-                      <div className="relative overflow-hidden rounded-[28px] border border-white/[0.09] bg-[oklch(0.15_0.02_248/0.6)] px-6 py-6 backdrop-blur-xl">
+                      <div className="surface-glass interactive-shimmer relative overflow-hidden rounded-[28px] px-6 py-6">
                         {/* Top gradient line */}
                         <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/35 to-transparent" />
 
@@ -671,41 +766,27 @@ export default function HomePage() {
                         </div>
                       </div>
 
-                      {/* Kroger gate notice */}
-                      {!krogerConnected && (
-                        <div className="mt-3 flex items-center gap-3 rounded-2xl border border-amber-400/18 bg-amber-400/7 px-4 py-3">
-                          <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400/70" />
-                          <p className="text-[13px] text-amber-200/75">
-                            Use the{" "}
-                            <span className="font-medium text-amber-200">Connect Kroger</span>{" "}
-                            button above to link your account before chatting.
-                          </p>
-                        </div>
-                      )}
-
                       {/* Suggestion chips */}
-                      {krogerConnected && (
-                        <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
-                          {EXAMPLES.map(({ icon: Icon, text }) => (
-                            <button
-                              key={text}
-                              type="button"
-                              onClick={() => submitPrompt(text)}
-                              className={cn(
-                                "group flex items-center gap-3 rounded-2xl border border-white/[0.08] bg-white/[0.04] px-4 py-3",
-                                "text-left text-[13px] text-white/60 transition-all duration-150",
-                                "hover:border-primary/30 hover:bg-primary/[0.08] hover:text-white/90",
-                                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50"
-                              )}
-                            >
-                              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-white/8 bg-white/5 transition-colors group-hover:border-primary/25 group-hover:bg-primary/10">
-                                <Icon className="h-3.5 w-3.5 text-white/45 transition-colors group-hover:text-primary/80" />
-                              </span>
-                              <span className="leading-snug">{text}</span>
-                            </button>
-                          ))}
-                        </div>
-                      )}
+                      <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                        {EXAMPLES.map(({ icon: Icon, text }) => (
+                          <button
+                            key={text}
+                            type="button"
+                            onClick={() => submitPrompt(text)}
+                            className={cn(
+                              "group flex items-center gap-3 rounded-2xl border border-white/[0.08] bg-white/[0.04] px-4 py-3",
+                              "text-left text-[13px] text-white/60 transition-all duration-150",
+                              "hover:border-primary/30 hover:bg-primary/[0.08] hover:text-white/90",
+                              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50",
+                            )}
+                          >
+                            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-white/8 bg-white/5 transition-colors group-hover:border-primary/25 group-hover:bg-primary/10">
+                              <Icon className="h-3.5 w-3.5 text-white/45 transition-colors group-hover:text-primary/80" />
+                            </span>
+                            <span className="leading-snug">{text}</span>
+                          </button>
+                        ))}
+                      </div>
                     </article>
                   </div>
                 )}
@@ -719,8 +800,8 @@ export default function HomePage() {
                     <div
                       className={
                         message.role === "user"
-                          ? "rounded-[22px] border border-primary/16 bg-gradient-to-br from-primary/14 to-primary/8 px-5 py-3.5 text-white shadow-[0_8px_30px_rgba(0,0,0,0.2)]"
-                          : "rounded-[24px] border border-white/[0.08] bg-[oklch(0.15_0.02_248/0.55)] px-5 py-4 text-white backdrop-blur-lg"
+                          ? "interactive-shimmer rounded-[22px] border border-primary/16 bg-gradient-to-br from-primary/14 to-primary/8 px-5 py-3.5 text-white shadow-[0_8px_30px_rgba(0,0,0,0.2)]"
+                          : "surface-glass-soft interactive-shimmer rounded-[24px] px-5 py-4 text-white"
                       }
                     >
                       <p
@@ -798,33 +879,37 @@ export default function HomePage() {
               </div>
 
               {/* ── Input bar ── */}
-              {krogerConnected ? (
-                <div className="border-t border-white/[0.07] bg-gradient-to-t from-[oklch(0.12_0.02_248/0.98)] via-[oklch(0.12_0.02_248/0.85)] to-transparent pt-3">
-                  <ChatInput
-                    onSubmit={submitPrompt}
-                    isLoading={isSending}
-                    placeholder="Ask for a recipe, groceries, or both…"
-                  />
-                </div>
-              ) : (
-                <div className="border-t border-white/[0.07] pt-3">
-                  <div
-                    className="flex items-center justify-center gap-2.5 rounded-2xl border border-amber-400/15 bg-amber-400/5 px-5 py-3.5"
-                    role="status"
-                    aria-label="Connect Kroger to enable chat"
-                  >
-                    <div className="h-1.5 w-1.5 rounded-full bg-amber-400/60" />
-                    <p className="text-[13px] text-amber-200/65">
-                      Connect Kroger above to start chatting
-                    </p>
-                  </div>
-                </div>
-              )}
+              <div className="border-t border-white/[0.07] bg-gradient-to-t from-[oklch(0.12_0.02_248/0.98)] via-[oklch(0.12_0.02_248/0.85)] to-transparent pt-3">
+                <ChatInput
+                  onSubmit={submitPrompt}
+                  isLoading={isSending}
+                  placeholder={
+                    krogerConnected || krogerIsMock
+                      ? "Ask for a recipe, groceries, or both…"
+                      : "Chat works now — link Kroger (top-right) when you want cart checkout…"
+                  }
+                />
+                {!krogerConnected && !krogerIsMock ? (
+                  <p className="mt-2 text-center text-[11px] text-white/32">
+                    Without Kroger, the assistant can browse ideas and prep lists — reconnect when you&apos;re ready to match products and carts.
+                  </p>
+                ) : null}
+              </div>
             </section>
           </div>
         </main>
       </div>
+
     </div>
+
+      <ConnectKrogerPromptDialog
+        open={krogerConnectPromptOpen}
+        onOpenChange={setKrogerConnectPromptOpen}
+        onConnected={handleKrogerConnected}
+        afterDismissPersist={() => setKrogerPromptDismissed(true)}
+      />
+    {onboardingOverlay}
+    </>
   )
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useState } from "react"
+import { flushSync } from "react-dom"
 import Link from "next/link"
 import {
   AlertCircle,
@@ -21,9 +22,15 @@ import { Button } from "@/components/ui/button"
 import { LoginScreen } from "@/components/LoginScreen"
 import { Sidebar, type ChatSession } from "@/components/Sidebar"
 import { KrogerConnectButton } from "@/components/KrogerConnectButton"
+import { buildChatMessagesForAgent, coerceReplayMessageContent } from "@/lib/chat/chatHistoryPayload"
+import {
+  needsAiChatTitle,
+  pickFirstUserMessageForSessionTitle,
+  resolvePersistedChatTitle,
+} from "@/lib/chat/sessionTitle"
 import { cn } from "@/lib/utils"
 import { WelcomeHero } from "@/components/WelcomeHero"
-import type { AgentStreamEvent, CartArtifact, ChatMessage, ToolTraceEntry, VideoArtifact } from "@/lib/types"
+import type { AgentStreamEvent, CartArtifact, ToolTraceEntry, VideoArtifact } from "@/lib/types"
 import type { AuthUserDto } from "@/components/LoginScreen"
 
 const EXAMPLES = [
@@ -235,7 +242,7 @@ export default function HomePage() {
           const restoredLs: UiMessage[] = stored.map((m) => ({
             id: m.id,
             role: m.role,
-            content: m.content,
+            content: coerceReplayMessageContent(m.role, m.content),
             status: "idle",
             traces: [],
             video: m.video as VideoArtifact | null,
@@ -253,7 +260,7 @@ export default function HomePage() {
       const restored: UiMessage[] = rows.map((m) => ({
         id: m.id,
         role: m.role,
-        content: m.content,
+        content: coerceReplayMessageContent(m.role, m.content),
         status: "idle",
         traces: [],
         video: m.video as VideoArtifact | null,
@@ -382,7 +389,7 @@ export default function HomePage() {
         method: "POST",
         credentials: "same-origin",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: toChatHistory(historyForRequest) }),
+        body: JSON.stringify({ messages: buildChatMessagesForAgent(historyForRequest) }),
       })
 
       if (response.status === 401) {
@@ -397,26 +404,35 @@ export default function HomePage() {
 
       await consumeEventStream(response.body, assistantMessage.id)
     } catch (error) {
-      updateAssistantMessage(assistantMessage.id, (current) => ({
-        ...current,
-        status: "error",
-        error: error instanceof Error ? error.message : "Could not reach the CraveCart agent.",
-        content: current.content || "I couldn't complete that request.",
-      }))
+      flushSync(() => {
+        updateAssistantMessage(assistantMessage.id, (current) => ({
+          ...current,
+          status: "error",
+          error: error instanceof Error ? error.message : "Could not reach the CraveCart agent.",
+          content: current.content || "I couldn't complete that request.",
+        }))
+      })
     } finally {
       setIsSending(false)
 
-      const titleForSave = (() => {
-        const fromRef = resolvedChatTitleRef.current.get(sessionId)
-        if (fromRef) return fromRef
-        const fromSidebar = sessionsRef.current.find((s) => s.id === sessionId)?.title
-        if (fromSidebar) return fromSidebar
-        return isFirstUserTurn ? "New chat" : prompt.length > 48 ? `${prompt.slice(0, 45)}…` : prompt
-      })()
+      const titleForSave = resolvePersistedChatTitle({
+        sessionId,
+        resolvedTitles: resolvedChatTitleRef.current,
+        sessions: sessionsRef.current,
+        isFirstUserTurn,
+        currentPrompt: prompt,
+      })
 
       persistSession(sessionId, titleForSave, latestMessagesRef.current)
 
-      if (isFirstUserTurn && !aiTitleRequestedRef.current.has(sessionId)) {
+      if (
+        needsAiChatTitle({
+          sessionId,
+          aiTitleRequested: aiTitleRequestedRef.current,
+          resolvedTitles: resolvedChatTitleRef.current,
+          sessions: sessionsRef.current,
+        })
+      ) {
         aiTitleRequestedRef.current.add(sessionId)
         void (async () => {
           try {
@@ -424,15 +440,28 @@ export default function HomePage() {
               method: "POST",
               credentials: "same-origin",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ firstMessage: prompt }),
+              body: JSON.stringify({
+                firstMessage: pickFirstUserMessageForSessionTitle({
+                  isFirstUserTurn,
+                  currentPrompt: prompt,
+                  priorMessages: messages,
+                }),
+              }),
             })
-            if (!tr.ok) return
+            if (!tr.ok) {
+              aiTitleRequestedRef.current.delete(sessionId)
+              return
+            }
             const body = (await tr.json()) as { title?: string }
             const nextTitle = body.title?.trim()
-            if (!nextTitle) return
+            if (!nextTitle) {
+              aiTitleRequestedRef.current.delete(sessionId)
+              return
+            }
             resolvedChatTitleRef.current.set(sessionId, nextTitle)
             setSessions((prev) => prev.map((s) => (s.id === sessionId ? { ...s, title: nextTitle } : s)))
             persistSession(sessionId, nextTitle, latestMessagesRef.current)
+            aiTitleRequestedRef.current.delete(sessionId)
           } catch {
             aiTitleRequestedRef.current.delete(sessionId)
           }
@@ -462,11 +491,13 @@ export default function HomePage() {
       }
     }
 
-    updateAssistantMessage(assistantId, (current) => ({
-      ...current,
-      status: current.status === "error" ? "error" : "idle",
-      content: current.content || "I finished the request.",
-    }))
+    flushSync(() => {
+      updateAssistantMessage(assistantId, (current) => ({
+        ...current,
+        status: current.status === "error" ? "error" : "idle",
+        content: current.content || "I finished the request.",
+      }))
+    })
   }
 
   function applyAgentEvent(assistantId: string, event: AgentStreamEvent) {
@@ -506,7 +537,7 @@ export default function HomePage() {
           ...c,
           status: "error",
           error: event.message,
-          content: c.content || event.message,
+          content: c.content || event.message?.trim() || "The agent could not finish that turn.",
         }))
         break
     }
@@ -805,10 +836,6 @@ function makeUserMessage(content: string): UiMessage {
 
 function makeAssistantPlaceholder(): UiMessage {
   return { id: makeMessageId(), role: "assistant", content: "", status: "streaming", traces: [], video: null, cart: null, authUrl: null, error: null }
-}
-
-function toChatHistory(messages: UiMessage[]): ChatMessage[] {
-  return messages.map((m) => ({ role: m.role, content: m.content }))
 }
 
 function parseSseEvent(block: string): AgentStreamEvent | null {

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,7 @@
 # - Grant the Cloud Run runtime SA (default compute) roles/secretmanager.secretAccessor
 #   on each secret you reference below.
 # - Create secrets: GEMINI_API_KEY, YOUTUBE_API_KEY, KROGER_CLIENT_ID, KROGER_CLIENT_SECRET,
+#   SUPADATA_API_KEY (recommended for native public-video captions),
 #   INTERNAL_SIDECAR_SECRET (shared with Fly Kroger MCP; never expose to browsers),
 #   FIREBASE_SERVICE_ACCOUNT_JSON (full service account JSON as one blob),
 #   FIREBASE_WEB_API_KEY (Firebase web API key — restrict domains in Firebase console).
@@ -134,7 +135,7 @@ steps:
           --memory 512Mi \
           --min-instances 0 \
           --max-instances 1 \
-          --set-secrets YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest
+          --set-secrets YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest,SUPADATA_API_KEY=SUPADATA_API_KEY:latest
         PN=$$(curl -fsS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/project/numeric-project-id")
         gcloud run services add-iam-policy-binding cravecart-youtube-mcp \
           --region "us-central1" \

--- a/components/CartReadyCard.tsx
+++ b/components/CartReadyCard.tsx
@@ -9,6 +9,7 @@ interface CartReadyCardProps {
 
 export function CartReadyCard({ cart }: CartReadyCardProps) {
   const isPartial = cart.status === "partial_cart_ready"
+  const recipeSourceLabel = cart.recipeSource === "none" ? "unknown" : cart.recipeSource.replace("_", " ")
 
   return (
     <section className="rounded-[32px] border border-white/20 bg-[linear-gradient(160deg,rgba(255,255,255,0.96),rgba(246,241,232,0.94))] p-6 shadow-[0_30px_120px_rgba(0,0,0,0.24)]">
@@ -39,7 +40,7 @@ export function CartReadyCard({ cart }: CartReadyCardProps) {
         <SummaryTile icon={ShoppingBag} label="Items Added" value={String(cart.itemsAdded)} />
         <SummaryTile icon={Store} label="Retailer" value={cart.retailer} />
         <SummaryTile icon={CheckCircle2} label="Estimated Total" value={cart.estimatedTotal} />
-        <SummaryTile icon={ShoppingBag} label="Recipe Source" value={cart.recipeSource.replace("_", " ")} />
+        <SummaryTile icon={ShoppingBag} label="Recipe Source" value={recipeSourceLabel} />
       </div>
 
       {cart.video ? (

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -46,7 +46,7 @@ export function ChatInput({
     <form onSubmit={handleSubmit} className={cn("w-full", className)}>
       <div
         className={cn(
-          "rounded-[22px] border bg-black/40 px-1 pt-1 pb-1 shadow-[0_8px_32px_rgba(0,0,0,0.28)] backdrop-blur-xl transition-all duration-200",
+          "surface-glass rounded-[22px] border px-1 pb-1 pt-1 transition-all duration-200",
           "focus-within:shadow-[0_8px_40px_rgba(0,0,0,0.35)]",
           overLimit
             ? "border-rose-500/30 focus-within:border-rose-500/50"
@@ -80,13 +80,14 @@ export function ChatInput({
 
             <Button
               type="submit"
-              size="icon"
+              size="icon-lg"
+              variant={value.trim() && !overLimit ? "cinematic" : "secondary"}
               disabled={!value.trim() || isLoading || overLimit}
               className={cn(
                 "h-9 w-9 rounded-full shadow-lg transition-all duration-200",
                 "hover:scale-[1.06] active:scale-95",
                 value.trim() && !overLimit
-                  ? "bg-primary text-primary-foreground shadow-primary/30 hover:bg-primary/90 hover:shadow-primary/40"
+                  ? "shadow-primary/30 hover:shadow-primary/40"
                   : "bg-white/8 text-white/30 shadow-none"
               )}
             >

--- a/components/ConnectKrogerBanner.tsx
+++ b/components/ConnectKrogerBanner.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { useSyncExternalStore, useState } from "react"
+import { Loader2, MapPin, ShoppingBag } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  KROGER_CONNECT_PENDING_STORAGE_KEY,
+  KROGER_PENDING_HANDOFF_EVENT,
+  startKrogerConnect,
+} from "@/lib/kroger/clientStartConnect"
+import { cn } from "@/lib/utils"
+
+function subscribePendingHandoff(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {}
+  const fire = () => onStoreChange()
+  window.addEventListener(KROGER_PENDING_HANDOFF_EVENT, fire)
+  window.addEventListener("focus", fire)
+  window.addEventListener("pageshow", fire)
+  return () => {
+    window.removeEventListener(KROGER_PENDING_HANDOFF_EVENT, fire)
+    window.removeEventListener("focus", fire)
+    window.removeEventListener("pageshow", fire)
+  }
+}
+
+function getPendingHandoffSnapshot() {
+  if (typeof window === "undefined") return false
+  return localStorage.getItem(KROGER_CONNECT_PENDING_STORAGE_KEY) === "1"
+}
+
+interface ConnectKrogerBannerProps {
+  onConnected: () => void
+}
+
+export function ConnectKrogerBanner({ onConnected }: ConnectKrogerBannerProps) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const hasPendingHandoff = useSyncExternalStore(subscribePendingHandoff, getPendingHandoffSnapshot, () => false)
+
+  async function handleConnect() {
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await startKrogerConnect()
+      if (result.kind === "mock") {
+        onConnected()
+        return
+      }
+      if (result.kind === "redirect") {
+        return
+      }
+      if (result.kind === "unauthorized") {
+        setError("Sign in again from the home page, then connect Kroger.")
+        return
+      }
+      setError(result.message ?? "Could not start Kroger connection.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div
+      role="region"
+      aria-label="Connect Kroger to enable chat"
+      className={cn(
+        "relative shrink-0 overflow-hidden border-b border-amber-400/20",
+        "bg-gradient-to-r from-amber-400/[0.09] via-amber-400/[0.06] to-transparent",
+        "px-4 py-3.5 backdrop-blur-md sm:px-6",
+      )}
+    >
+      <div className="mx-auto flex max-w-6xl flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-amber-400/25 bg-amber-400/10">
+            <ShoppingBag className="h-4 w-4 text-amber-200/90" aria-hidden />
+          </span>
+          <div className="min-w-0 space-y-1">
+            <p className="text-[14px] font-semibold leading-snug text-amber-100/95">
+              Connect Kroger to start chatting
+            </p>
+            <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] leading-relaxed text-amber-200/65">
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-3.5 w-3.5 shrink-0 text-amber-300/70" aria-hidden />
+                Real US grocery inventory, pickup & delivery — checkout stays on Kroger.
+              </span>
+              <span className="text-amber-200/45">OAuth keeps your password off our servers.</span>
+            </p>
+            {hasPendingHandoff ? (
+              <p className="text-[12px] text-emerald-200/85">
+                Handoff in progress detected. If you just finished Kroger sign-in, press connect to resume.
+              </p>
+            ) : null}
+            {error ? <p className="text-[12px] text-rose-300/95">{error}</p> : null}
+          </div>
+        </div>
+        <Button
+          type="button"
+          disabled={busy}
+          onClick={() => void handleConnect()}
+          className={cn(
+            "h-10 shrink-0 rounded-full bg-gradient-to-r from-amber-400/95 to-amber-500/90 px-6 text-[13px] font-semibold text-amber-950 shadow-lg shadow-amber-500/15",
+            "hover:brightness-110 disabled:opacity-50",
+          )}
+        >
+          {busy ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Connecting…
+            </>
+          ) : (
+            <>
+              <ShoppingBag className="h-4 w-4" />
+              {hasPendingHandoff ? "Resume Kroger connect" : "Connect Kroger"}
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/components/ConnectKrogerBanner.tsx
+++ b/components/ConnectKrogerBanner.tsx
@@ -28,11 +28,7 @@ function getPendingHandoffSnapshot() {
   return localStorage.getItem(KROGER_CONNECT_PENDING_STORAGE_KEY) === "1"
 }
 
-interface ConnectKrogerBannerProps {
-  onConnected: () => void
-}
-
-export function ConnectKrogerBanner({ onConnected }: ConnectKrogerBannerProps) {
+export function ConnectKrogerBanner() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const hasPendingHandoff = useSyncExternalStore(subscribePendingHandoff, getPendingHandoffSnapshot, () => false)
@@ -42,10 +38,6 @@ export function ConnectKrogerBanner({ onConnected }: ConnectKrogerBannerProps) {
     setError(null)
     try {
       const result = await startKrogerConnect()
-      if (result.kind === "mock") {
-        onConnected()
-        return
-      }
       if (result.kind === "redirect") {
         return
       }

--- a/components/ConnectKrogerPromptDialog.tsx
+++ b/components/ConnectKrogerPromptDialog.tsx
@@ -21,7 +21,6 @@ import {
 interface ConnectKrogerPromptDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onConnected: () => void
   /** Bump parent UI (e.g. nudge Kroger chip) once dismiss is persisted */
   afterDismissPersist: () => void
 }
@@ -29,15 +28,10 @@ interface ConnectKrogerPromptDialogProps {
 export function ConnectKrogerPromptDialog({
   open,
   onOpenChange,
-  onConnected,
   afterDismissPersist,
 }: ConnectKrogerPromptDialogProps) {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  function closeWithoutSavingDismiss() {
-    onOpenChange(false)
-  }
 
   function userDismissed() {
     if (typeof window !== "undefined") {
@@ -52,14 +46,6 @@ export function ConnectKrogerPromptDialog({
     setError(null)
     try {
       const result = await startKrogerConnect()
-      if (result.kind === "mock") {
-        if (typeof window !== "undefined") {
-          clearKrogerConnectPromptDismissed(sessionStorage)
-        }
-        onConnected()
-        closeWithoutSavingDismiss()
-        return
-      }
       if (result.kind === "redirect") {
         if (typeof window !== "undefined") {
           clearKrogerConnectPromptDismissed(sessionStorage)

--- a/components/ConnectKrogerPromptDialog.tsx
+++ b/components/ConnectKrogerPromptDialog.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useState } from "react"
+import { Loader2, ShoppingBag, X } from "lucide-react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { startKrogerConnect } from "@/lib/kroger/clientStartConnect"
+import {
+  clearKrogerConnectPromptDismissed,
+  setKrogerConnectPromptDismissed,
+} from "@/lib/kroger/connectPromptSession"
+
+interface ConnectKrogerPromptDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConnected: () => void
+  /** Bump parent UI (e.g. nudge Kroger chip) once dismiss is persisted */
+  afterDismissPersist: () => void
+}
+
+export function ConnectKrogerPromptDialog({
+  open,
+  onOpenChange,
+  onConnected,
+  afterDismissPersist,
+}: ConnectKrogerPromptDialogProps) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  function closeWithoutSavingDismiss() {
+    onOpenChange(false)
+  }
+
+  function userDismissed() {
+    if (typeof window !== "undefined") {
+      setKrogerConnectPromptDismissed(sessionStorage)
+    }
+    afterDismissPersist()
+    onOpenChange(false)
+  }
+
+  async function handleConnect() {
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await startKrogerConnect()
+      if (result.kind === "mock") {
+        if (typeof window !== "undefined") {
+          clearKrogerConnectPromptDismissed(sessionStorage)
+        }
+        onConnected()
+        closeWithoutSavingDismiss()
+        return
+      }
+      if (result.kind === "redirect") {
+        if (typeof window !== "undefined") {
+          clearKrogerConnectPromptDismissed(sessionStorage)
+        }
+        return
+      }
+      if (result.kind === "unauthorized") {
+        setError("Stay signed into CraveCart, then try again.")
+        return
+      }
+      setError(result.message ?? "Could not start Kroger.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showClose={false}
+        overlayClassName="z-[115] bg-black/75 backdrop-blur-md"
+        onInteractOutside={(e) => {
+          e.preventDefault()
+          userDismissed()
+        }}
+        onEscapeKeyDown={() => userDismissed()}
+        className="z-[120] max-w-md border-white/12 bg-[oklch(0.13_0.02_248/0.98)] backdrop-blur-xl shadow-2xl"
+      >
+        <DialogPrimitive.Close
+          type="button"
+          className="absolute right-4 top-4 rounded-lg p-1.5 text-white/45 opacity-90 transition-colors hover:bg-white/10 hover:text-white focus-visible:outline focus-visible:ring-2 focus-visible:ring-amber-400/40 disabled:pointer-events-none"
+          aria-label="Close"
+          onClick={(e) => {
+            e.preventDefault()
+            userDismissed()
+          }}
+        >
+          <X className="h-4 w-4" />
+        </DialogPrimitive.Close>
+        <DialogHeader className="space-y-3 text-left">
+          <div className="flex h-11 w-11 items-center justify-center rounded-2xl border border-amber-400/28 bg-amber-400/10">
+            <ShoppingBag className="h-5 w-5 text-amber-200/90" aria-hidden />
+          </div>
+          <DialogTitle className="text-xl text-white">
+            Link your Kroger account
+          </DialogTitle>
+          <DialogDescription className="text-[14px] leading-relaxed text-white/55">
+            Sign in once with Kroger (OAuth — your password never touches CraveCart) so search, cart adds, and
+            checkout reflect your real store. You can still chat without linking, but cart features need Kroger.
+          </DialogDescription>
+        </DialogHeader>
+        {error ? (
+          <p className="rounded-xl border border-rose-500/25 bg-rose-500/10 px-3 py-2 text-[13px] text-rose-200/95">
+            {error}
+          </p>
+        ) : null}
+        <DialogFooter className="gap-2 sm:flex-col-reverse sm:space-x-0">
+          <Button
+            type="button"
+            variant="ghost"
+            className="rounded-full text-white/45 hover:bg-white/[0.06] hover:text-white/75"
+            disabled={busy}
+            onClick={userDismissed}
+          >
+            Not now — I&apos;ll chat without Kroger
+          </Button>
+          <Button
+            type="button"
+            variant="cinematic"
+            disabled={busy}
+            onClick={() => void handleConnect()}
+            className="h-11 w-full rounded-full sm:h-12 sm:w-auto sm:min-w-[200px]"
+          >
+            {busy ? (
+              <>
+                <Loader2 className="h-5 w-5 animate-spin" />
+                Opening Kroger…
+              </>
+            ) : (
+              <>
+                <ShoppingBag className="h-5 w-5" />
+                Connect Kroger
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/KrogerAuthClient.tsx
+++ b/components/KrogerAuthClient.tsx
@@ -1,9 +1,11 @@
 "use client"
 
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { useEffect, useState } from "react"
-import { ArrowLeft, Loader2 } from "lucide-react"
+import { ArrowLeft, CheckCircle2, Loader2, ShoppingBag, Sparkles, Youtube } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { clearKrogerConnectRedirectPending } from "@/lib/kroger/clientStartConnect"
 
 interface StartAuthState {
   mode: "loading" | "connected" | "error"
@@ -15,13 +17,33 @@ interface KrogerAuthClientProps {
 }
 
 export function KrogerAuthClient({ initialState }: KrogerAuthClientProps) {
+  const router = useRouter()
   const [state, setState] = useState<StartAuthState>(initialState)
+  const [redirectSeconds, setRedirectSeconds] = useState(5)
 
   useEffect(() => {
     if (state.mode === "connected") {
+      clearKrogerConnectRedirectPending()
       localStorage.setItem("cravecart_kroger_connected", "1")
     }
   }, [state.mode])
+
+  useEffect(() => {
+    if (state.mode !== "connected") return
+
+    const interval = window.setInterval(() => {
+      setRedirectSeconds((s) => (s > 0 ? s - 1 : 0))
+    }, 1000)
+
+    const redirect = window.setTimeout(() => {
+      router.push("/")
+    }, 5000)
+
+    return () => {
+      window.clearInterval(interval)
+      window.clearTimeout(redirect)
+    }
+  }, [state.mode, router])
 
   useEffect(() => {
     if (state.mode !== "loading") {
@@ -32,6 +54,7 @@ export function KrogerAuthClient({ initialState }: KrogerAuthClientProps) {
 
     void fetch("/api/kroger/auth/start", {
       method: "POST",
+      credentials: "same-origin",
     })
       .then(async (response) => {
         const payload = (await response.json()) as {
@@ -87,41 +110,76 @@ export function KrogerAuthClient({ initialState }: KrogerAuthClientProps) {
 
   return (
     <main className="relative z-10 flex min-h-screen items-center justify-center px-4 py-10">
-      <section className="w-full max-w-xl rounded-[32px] border border-white/15 bg-black/40 p-8 text-white backdrop-blur-2xl">
-        <Link href="/" className="inline-flex items-center gap-2 text-sm text-white/60 hover:text-white">
+      <section className="w-full max-w-xl rounded-[32px] border border-white/12 bg-[oklch(0.12_0.02_248/0.92)] p-8 text-white shadow-2xl backdrop-blur-2xl">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm text-white/55 transition-colors hover:text-white"
+        >
           <ArrowLeft className="h-4 w-4" />
           Back to CraveCart
         </Link>
 
         {state.mode === "loading" ? (
-          <div className="mt-8 space-y-3">
-            <Loader2 className="h-6 w-6 animate-spin text-primary" />
-            <h1 className="text-3xl font-semibold">Connecting to Kroger</h1>
-            <p className="text-sm text-white/70">Redirecting you to Kroger authorization.</p>
+          <div className="mt-10 space-y-4">
+            <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden />
+            <h1 className="text-3xl font-semibold tracking-tight">Connecting to Kroger</h1>
+            <p className="max-w-md text-[15px] leading-relaxed text-white/55">
+              Redirecting you to Kroger&apos;s secure sign-in. Your password never passes through CraveCart.
+            </p>
+            <p className="text-[12px] text-white/40">After Kroger login, you&apos;ll return here automatically and continue onboarding.</p>
           </div>
         ) : null}
 
         {state.mode === "connected" ? (
-          <div className="mt-8 space-y-4">
-            <h1 className="text-3xl font-semibold">Kroger connected</h1>
-            <p className="text-sm text-white/70">Return home and rerun the craving to push items into the live cart.</p>
-            <Link href="/">
-              <Button className="rounded-full bg-primary px-6 text-primary-foreground hover:bg-primary/90">
-                Back to home
-              </Button>
-            </Link>
+          <div className="mt-10 space-y-6">
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-emerald-400/30 bg-emerald-500/15">
+                <CheckCircle2 className="h-7 w-7 text-emerald-400" aria-hidden />
+              </div>
+              <div>
+                <h1 className="text-3xl font-semibold tracking-tight">You&apos;re linked</h1>
+                <p className="mt-1 text-sm text-white/45">
+                  Redirecting home in {redirectSeconds}s to resume chat…
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-white/[0.04] px-5 py-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/35">What unlocks now</p>
+              <ul className="mt-4 space-y-3 text-[14px] leading-snug text-white/65">
+                <li className="flex gap-3">
+                  <Youtube className="mt-0.5 h-5 w-5 shrink-0 text-primary/90" aria-hidden />
+                  <span>Recipe runs pull ingredients from real videos with Gemini + YouTube tools.</span>
+                </li>
+                <li className="flex gap-3">
+                  <ShoppingBag className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400/90" aria-hidden />
+                  <span>Kroger search uses your shopper token — better matches near your store.</span>
+                </li>
+                <li className="flex gap-3">
+                  <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-amber-300/90" aria-hidden />
+                  <span>Ask for groceries in chat — we can add matched items to your live cart.</span>
+                </li>
+              </ul>
+            </div>
+
+            <Button asChild className="rounded-full bg-primary px-8 text-primary-foreground hover:bg-primary/90">
+              <Link href="/">Back to home now</Link>
+            </Button>
           </div>
         ) : null}
 
         {state.mode === "error" ? (
-          <div className="mt-8 space-y-4">
-            <h1 className="text-3xl font-semibold">Could not connect Kroger</h1>
-            <p className="text-sm text-rose-200">{state.message}</p>
-            <Link href="/">
-              <Button variant="secondary" className="rounded-full px-6">
-                Back to home
-              </Button>
-            </Link>
+          <div className="mt-10 space-y-5">
+            <div className="rounded-2xl border border-rose-500/25 bg-rose-500/10 px-5 py-4">
+              <h1 className="text-xl font-semibold text-rose-100">Couldn&apos;t connect Kroger</h1>
+              <p className="mt-2 text-[14px] leading-relaxed text-rose-200/85">{state.message}</p>
+            </div>
+            <p className="text-[13px] text-white/45">
+              Tip: open CraveCart while signed in, then use <span className="text-white/65">Connect Kroger</span> from the header.
+            </p>
+            <Button asChild variant="secondary" className="rounded-full px-8">
+              <Link href="/">Back to home</Link>
+            </Button>
           </div>
         ) : null}
       </section>

--- a/components/KrogerAuthClient.tsx
+++ b/components/KrogerAuthClient.tsx
@@ -43,6 +43,14 @@ export function KrogerAuthClient({ initialState }: KrogerAuthClientProps) {
           return
         }
 
+        if (response.status === 401) {
+          setState({
+            mode: "error",
+            message: "Sign in to CraveCart from the home page, then connect Kroger from there.",
+          })
+          return
+        }
+
         if (!response.ok) {
           setState({
             mode: "error",

--- a/components/KrogerConnectButton.tsx
+++ b/components/KrogerConnectButton.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { Loader2, LogOut, ShoppingBag } from "lucide-react"
+import { clearKrogerConnectRedirectPending, startKrogerConnect } from "@/lib/kroger/clientStartConnect"
 import { cn } from "@/lib/utils"
 
 type ConnectStatus = "idle" | "loading" | "connected" | "mock"
@@ -9,6 +10,8 @@ type ConnectStatus = "idle" | "loading" | "connected" | "mock"
 interface KrogerConnectButtonProps {
   isConnected: boolean
   isMock: boolean
+  /** Gentle motion + glow — use when user dismissed the Kroger prompt but hasn’t linked yet */
+  attentionNudge?: boolean
   onConnected: () => void
   onDisconnected: () => Promise<void>
 }
@@ -16,6 +19,7 @@ interface KrogerConnectButtonProps {
 export function KrogerConnectButton({
   isConnected,
   isMock,
+  attentionNudge = false,
   onConnected,
   onDisconnected,
 }: KrogerConnectButtonProps) {
@@ -23,6 +27,7 @@ export function KrogerConnectButton({
     !isConnected ? "idle" : isMock ? "mock" : "connected",
   )
   const [disconnecting, setDisconnecting] = useState(false)
+  const [connectHint, setConnectHint] = useState<string | null>(null)
 
   useEffect(() => {
     setStatus(!isConnected ? "idle" : isMock ? "mock" : "connected")
@@ -31,33 +36,26 @@ export function KrogerConnectButton({
   async function handleConnect() {
     if (status !== "idle") return
     setStatus("loading")
+    setConnectHint("Preparing secure Kroger handoff...")
 
     try {
-      const res = await fetch("/api/kroger/auth/start", { method: "POST" })
-      const data = (await res.json()) as { mockMode?: boolean; authUrl?: string; message?: string; error?: string }
+      const result = await startKrogerConnect()
 
-      if (res.status === 401) {
-        setStatus("idle")
-        return
-      }
-
-      if (data.mockMode) {
+      if (result.kind === "mock") {
         setStatus("mock")
-        localStorage.setItem("cravecart_kroger_connected", "1")
-        localStorage.setItem("cravecart_kroger_mock", "1")
         onConnected()
         return
       }
 
-      if (data.authUrl) {
-        localStorage.setItem("cravecart_kroger_pending", "1")
-        window.location.assign(data.authUrl)
+      if (result.kind === "redirect") {
         return
       }
 
       setStatus("idle")
+      setConnectHint("Could not start connect flow.")
     } catch {
       setStatus("idle")
+      setConnectHint("Network issue while connecting.")
     }
   }
 
@@ -69,7 +67,7 @@ export function KrogerConnectButton({
       setStatus("idle")
       localStorage.removeItem("cravecart_kroger_connected")
       localStorage.removeItem("cravecart_kroger_mock")
-      localStorage.removeItem("cravecart_kroger_pending")
+      clearKrogerConnectRedirectPending()
     } finally {
       setDisconnecting(false)
     }
@@ -119,24 +117,28 @@ export function KrogerConnectButton({
   }
 
   return (
-    <button
-      onClick={handleConnect}
-      disabled={status === "loading"}
-      aria-label="Connect your Kroger account"
-      className={cn(
-        "group flex items-center gap-2 rounded-full border border-amber-400/22 bg-amber-400/8 px-3 py-1.5 text-[13px] font-medium text-amber-200/90",
-        "transition-all duration-200",
-        "hover:border-amber-400/40 hover:bg-amber-400/14 hover:text-amber-100 hover:shadow-[0_0_16px_rgba(251,191,36,0.12)]",
-        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400/50",
-        "disabled:cursor-not-allowed disabled:opacity-50",
-      )}
-    >
-      {status === "loading" ? (
-        <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden="true" />
-      ) : (
-        <ShoppingBag className="h-4 w-4 shrink-0 transition-transform duration-200 group-hover:scale-110" aria-hidden="true" />
-      )}
-      <span className="hidden sm:inline">{status === "loading" ? "Connecting…" : "Connect Kroger"}</span>
-    </button>
+    <div className="flex flex-col items-end gap-1">
+      <button
+        onClick={handleConnect}
+        disabled={status === "loading"}
+        aria-label="Connect your Kroger account"
+        className={cn(
+          "group flex items-center gap-2 rounded-full border border-amber-400/22 bg-amber-400/8 px-3 py-1.5 text-[13px] font-medium text-amber-200/90",
+          "transition-all duration-200",
+          "hover:border-amber-400/40 hover:bg-amber-400/14 hover:text-amber-100 hover:shadow-[0_0_16px_rgba(251,191,36,0.12)]",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400/50",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          attentionNudge && status === "idle" && "relative z-[1] border-amber-400/55 ring-2 ring-amber-400/30 kroger-connect-nudge motion-reduce:animate-none motion-reduce:ring-amber-400/20",
+        )}
+      >
+        {status === "loading" ? (
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden="true" />
+        ) : (
+          <ShoppingBag className="h-4 w-4 shrink-0 transition-transform duration-200 group-hover:scale-110" aria-hidden="true" />
+        )}
+        <span className="hidden sm:inline">{status === "loading" ? "Connecting…" : "Connect Kroger"}</span>
+      </button>
+      {status === "loading" && connectHint ? <p className="text-[10px] text-white/35">{connectHint}</p> : null}
+    </div>
   )
 }

--- a/components/KrogerConnectButton.tsx
+++ b/components/KrogerConnectButton.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState } from "react"
-import { CheckCircle2, Loader2, ShoppingBag } from "lucide-react"
+import { useEffect, useState } from "react"
+import { Loader2, LogOut, ShoppingBag } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 type ConnectStatus = "idle" | "loading" | "connected" | "mock"
@@ -10,13 +10,23 @@ interface KrogerConnectButtonProps {
   isConnected: boolean
   isMock: boolean
   onConnected: () => void
+  onDisconnected: () => Promise<void>
 }
 
-export function KrogerConnectButton({ isConnected, isMock, onConnected }: KrogerConnectButtonProps) {
-  const [status, setStatus] = useState<ConnectStatus>(() => {
-    if (!isConnected) return "idle"
-    return isMock ? "mock" : "connected"
-  })
+export function KrogerConnectButton({
+  isConnected,
+  isMock,
+  onConnected,
+  onDisconnected,
+}: KrogerConnectButtonProps) {
+  const [status, setStatus] = useState<ConnectStatus>(() =>
+    !isConnected ? "idle" : isMock ? "mock" : "connected",
+  )
+  const [disconnecting, setDisconnecting] = useState(false)
+
+  useEffect(() => {
+    setStatus(!isConnected ? "idle" : isMock ? "mock" : "connected")
+  }, [isConnected, isMock])
 
   async function handleConnect() {
     if (status !== "idle") return
@@ -24,7 +34,12 @@ export function KrogerConnectButton({ isConnected, isMock, onConnected }: Kroger
 
     try {
       const res = await fetch("/api/kroger/auth/start", { method: "POST" })
-      const data = (await res.json()) as { mockMode?: boolean; authUrl?: string }
+      const data = (await res.json()) as { mockMode?: boolean; authUrl?: string; message?: string; error?: string }
+
+      if (res.status === 401) {
+        setStatus("idle")
+        return
+      }
 
       if (data.mockMode) {
         setStatus("mock")
@@ -46,26 +61,59 @@ export function KrogerConnectButton({ isConnected, isMock, onConnected }: Kroger
     }
   }
 
+  async function handleDisconnect() {
+    if (disconnecting) return
+    setDisconnecting(true)
+    try {
+      await onDisconnected()
+      setStatus("idle")
+      localStorage.removeItem("cravecart_kroger_connected")
+      localStorage.removeItem("cravecart_kroger_mock")
+      localStorage.removeItem("cravecart_kroger_pending")
+    } finally {
+      setDisconnecting(false)
+    }
+  }
+
   const connected = status === "connected" || status === "mock"
 
   if (connected) {
     return (
-      <div
-        role="status"
-        aria-label={status === "mock" ? "Kroger mock mode active" : "Kroger connected"}
-        className={cn(
-          "flex items-center gap-2 rounded-full border border-green-500/25 bg-green-500/10 px-3 py-1.5 text-sm text-green-300",
-          "shadow-[0_0_18px_rgba(34,197,94,0.14)] transition-shadow duration-1000"
-        )}
-      >
-        {/* Ping dot */}
-        <span className="relative flex h-2 w-2 shrink-0">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-50" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-green-400" />
-        </span>
-        <span className="hidden sm:inline text-[13px] font-medium">
-          {status === "mock" ? "Kroger (mock)" : "Kroger connected"}
-        </span>
+      <div className="flex max-w-[min(100%,380px)] items-center gap-2 sm:gap-3">
+        <div
+          role="status"
+          aria-label={status === "mock" ? "Kroger mock mode active" : "Kroger connected"}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-2 rounded-full border border-green-500/25 bg-green-500/10 px-3 py-1.5 text-sm text-green-300",
+            "shadow-[0_0_18px_rgba(34,197,94,0.14)] transition-shadow duration-1000",
+          )}
+        >
+          <span className="relative flex h-2 w-2 shrink-0">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-50" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-green-400" />
+          </span>
+          <span className="hidden truncate sm:inline text-[13px] font-medium">
+            {status === "mock" ? "Kroger (mock)" : "Kroger connected"}
+          </span>
+        </div>
+        <button
+          type="button"
+          disabled={disconnecting}
+          onClick={() => void handleDisconnect()}
+          className={cn(
+            "flex shrink-0 items-center gap-1.5 rounded-full border border-white/14 bg-white/[0.06] px-2.5 py-1.5 text-[12px] font-medium text-white/75",
+            "hover:border-white/25 hover:bg-white/10 hover:text-white",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400/50",
+            "disabled:pointer-events-none disabled:opacity-45",
+          )}
+        >
+          {disconnecting ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+          ) : (
+            <LogOut className="h-3.5 w-3.5" aria-hidden />
+          )}
+          <span className="hidden sm:inline">Disconnect</span>
+        </button>
       </div>
     )
   }
@@ -80,7 +128,7 @@ export function KrogerConnectButton({ isConnected, isMock, onConnected }: Kroger
         "transition-all duration-200",
         "hover:border-amber-400/40 hover:bg-amber-400/14 hover:text-amber-100 hover:shadow-[0_0_16px_rgba(251,191,36,0.12)]",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400/50",
-        "disabled:cursor-not-allowed disabled:opacity-50"
+        "disabled:cursor-not-allowed disabled:opacity-50",
       )}
     >
       {status === "loading" ? (
@@ -88,9 +136,7 @@ export function KrogerConnectButton({ isConnected, isMock, onConnected }: Kroger
       ) : (
         <ShoppingBag className="h-4 w-4 shrink-0 transition-transform duration-200 group-hover:scale-110" aria-hidden="true" />
       )}
-      <span className="hidden sm:inline">
-        {status === "loading" ? "Connecting…" : "Connect Kroger"}
-      </span>
+      <span className="hidden sm:inline">{status === "loading" ? "Connecting…" : "Connect Kroger"}</span>
     </button>
   )
 }

--- a/components/KrogerConnectButton.tsx
+++ b/components/KrogerConnectButton.tsx
@@ -5,57 +5,55 @@ import { Loader2, LogOut, ShoppingBag } from "lucide-react"
 import { clearKrogerConnectRedirectPending, startKrogerConnect } from "@/lib/kroger/clientStartConnect"
 import { cn } from "@/lib/utils"
 
-type ConnectStatus = "idle" | "loading" | "connected" | "mock"
+type ConnectStatus = "idle" | "loading" | "connected"
 
 interface KrogerConnectButtonProps {
   isConnected: boolean
-  isMock: boolean
   /** Gentle motion + glow — use when user dismissed the Kroger prompt but hasn’t linked yet */
   attentionNudge?: boolean
-  onConnected: () => void
   onDisconnected: () => Promise<void>
 }
 
 export function KrogerConnectButton({
   isConnected,
-  isMock,
   attentionNudge = false,
-  onConnected,
   onDisconnected,
 }: KrogerConnectButtonProps) {
-  const [status, setStatus] = useState<ConnectStatus>(() =>
-    !isConnected ? "idle" : isMock ? "mock" : "connected",
-  )
+  const [status, setStatus] = useState<ConnectStatus>(() => (!isConnected ? "idle" : "connected"))
   const [disconnecting, setDisconnecting] = useState(false)
   const [connectHint, setConnectHint] = useState<string | null>(null)
+  /** Shown after a failed start (cleared on the next connect attempt). */
+  const [connectError, setConnectError] = useState<string | null>(null)
 
   useEffect(() => {
-    setStatus(!isConnected ? "idle" : isMock ? "mock" : "connected")
-  }, [isConnected, isMock])
+    setStatus(!isConnected ? "idle" : "connected")
+  }, [isConnected])
 
   async function handleConnect() {
     if (status !== "idle") return
     setStatus("loading")
+    setConnectError(null)
     setConnectHint("Preparing secure Kroger handoff...")
 
     try {
       const result = await startKrogerConnect()
-
-      if (result.kind === "mock") {
-        setStatus("mock")
-        onConnected()
-        return
-      }
 
       if (result.kind === "redirect") {
         return
       }
 
       setStatus("idle")
-      setConnectHint("Could not start connect flow.")
+      setConnectHint(null)
+      if (result.kind === "unauthorized") {
+        setConnectError("Sign in to connect your Kroger account.")
+        return
+      }
+      const detail = result.message?.trim()
+      setConnectError(detail || "Could not start connect flow.")
     } catch {
       setStatus("idle")
-      setConnectHint("Network issue while connecting.")
+      setConnectHint(null)
+      setConnectError("Network issue while connecting.")
     }
   }
 
@@ -66,21 +64,20 @@ export function KrogerConnectButton({
       await onDisconnected()
       setStatus("idle")
       localStorage.removeItem("cravecart_kroger_connected")
-      localStorage.removeItem("cravecart_kroger_mock")
       clearKrogerConnectRedirectPending()
     } finally {
       setDisconnecting(false)
     }
   }
 
-  const connected = status === "connected" || status === "mock"
+  const connected = status === "connected"
 
   if (connected) {
     return (
       <div className="flex max-w-[min(100%,380px)] items-center gap-2 sm:gap-3">
         <div
           role="status"
-          aria-label={status === "mock" ? "Kroger mock mode active" : "Kroger connected"}
+          aria-label="Kroger connected"
           className={cn(
             "flex min-w-0 flex-1 items-center gap-2 rounded-full border border-green-500/25 bg-green-500/10 px-3 py-1.5 text-sm text-green-300",
             "shadow-[0_0_18px_rgba(34,197,94,0.14)] transition-shadow duration-1000",
@@ -90,9 +87,7 @@ export function KrogerConnectButton({
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-50" />
             <span className="relative inline-flex h-2 w-2 rounded-full bg-green-400" />
           </span>
-          <span className="hidden truncate sm:inline text-[13px] font-medium">
-            {status === "mock" ? "Kroger (mock)" : "Kroger connected"}
-          </span>
+          <span className="hidden truncate sm:inline text-[13px] font-medium">Kroger connected</span>
         </div>
         <button
           type="button"
@@ -138,7 +133,12 @@ export function KrogerConnectButton({
         )}
         <span className="hidden sm:inline">{status === "loading" ? "Connecting…" : "Connect Kroger"}</span>
       </button>
-      {status === "loading" && connectHint ? <p className="text-[10px] text-white/35">{connectHint}</p> : null}
+      {status === "loading" && connectHint ? (
+        <p className="text-[10px] text-white/35">{connectHint}</p>
+      ) : null}
+      {status === "idle" && connectError ? (
+        <p className="max-w-[min(100%,280px)] text-right text-[10px] leading-snug text-amber-200/75">{connectError}</p>
+      ) : null}
     </div>
   )
 }

--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -17,6 +17,8 @@ import {
   sendCravecartPasswordResetEmail,
   type LoadedFirebaseBrowserConfig,
 } from "@/lib/firebase/clientAuth"
+import { ONBOARDING_STEPS } from "@/lib/onboarding/narrative"
+import { isReturningVisitor, markVisited } from "@/lib/onboarding/state"
 import { cn } from "@/lib/utils"
 
 type Tab = "signin" | "signup"
@@ -58,6 +60,15 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
   /** Forgot password panel */
   const [fpEmail, setFpEmail] = useState("")
   const [fpDone, setFpDone] = useState(false)
+
+  const [visitorKind] = useState<"fresh" | "returning">(() => {
+    if (typeof window === "undefined") return "fresh"
+    return isReturningVisitor(window.localStorage) ? "returning" : "fresh"
+  })
+
+  useEffect(() => {
+    markVisited(window.localStorage)
+  }, [])
 
   async function loadAuthedUserFromMe(): Promise<AuthUserDto | null> {
     const meRes = await fetch("/api/auth/me", { credentials: "same-origin" })
@@ -230,22 +241,19 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
 
   if (showForgot) {
     return (
-      <main className="relative z-10 flex min-h-screen items-center justify-center px-4 py-12">
-        <div className="w-full max-w-[420px] space-y-7">
-          <div className="flex flex-col items-center text-center">
-            <div className="relative mb-4 inline-flex">
-              <div className="absolute inset-0 rounded-2xl bg-primary/30 blur-xl" />
-              <div className="relative flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/25 via-primary/12 to-transparent shadow-xl shadow-primary/10">
-                <ShoppingCart className="h-[26px] w-[26px] text-primary" />
-              </div>
-            </div>
+      <main className="relative z-10 min-h-screen px-4 py-10 lg:flex lg:items-center lg:justify-center lg:py-12">
+        <div className="mx-auto grid w-full max-w-6xl gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:gap-14">
+          <BrandStoryPanel variant={visitorKind} />
+
+          <div className="mx-auto w-full max-w-[440px] space-y-6 lg:mx-0 lg:justify-self-end">
+          <div className="flex flex-col items-center text-center lg:items-start lg:text-left">
             <h1 className="text-[26px] font-semibold tracking-tight text-white">Reset password</h1>
             <p className="mt-1.5 max-w-xs text-sm leading-relaxed text-white/42">
               {fpDone ? "Check your email for a reset link from Firebase." : "We’ll email reset instructions."}
             </p>
           </div>
 
-          <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-[oklch(0.135_0.02_248/0.85)] shadow-2xl shadow-black/50 backdrop-blur-2xl">
+          <div className="surface-glass cinematic-divider relative overflow-hidden rounded-[28px]">
             <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
             <div className="px-7 py-6">
               {fpDone ? (
@@ -297,28 +305,20 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
               )}
             </div>
           </div>
+          </div>
         </div>
       </main>
     )
   }
 
   return (
-    <main className="relative z-10 flex min-h-screen items-center justify-center px-4 py-12">
-      <div className="w-full max-w-[420px] space-y-7">
-        {/* Brand */}
-        <div className="flex flex-col items-center text-center">
-          <div className="relative mb-4 inline-flex">
-            <div className="absolute inset-0 rounded-2xl bg-primary/30 blur-xl" />
-            <div className="relative flex h-[60px] w-[60px] items-center justify-center rounded-2xl border border-primary/30 bg-gradient-to-br from-primary/25 via-primary/12 to-transparent shadow-xl shadow-primary/10">
-              <ShoppingCart className="h-[26px] w-[26px] text-primary" />
-            </div>
-          </div>
-          <h1 className="text-[26px] font-semibold tracking-tight text-white">CraveCart</h1>
-          <p className="mt-1.5 max-w-xs text-sm leading-relaxed text-white/42">AI-powered food planning and grocery shopping</p>
-        </div>
+    <main className="relative z-10 min-h-screen px-4 py-10 lg:flex lg:items-center lg:justify-center lg:py-12">
+      <div className="mx-auto grid w-full max-w-6xl gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:gap-14">
+        <BrandStoryPanel variant={visitorKind} />
 
+        <div className="mx-auto w-full max-w-[440px] space-y-6 lg:mx-0 lg:justify-self-end">
         {/* Auth card */}
-        <div className="relative overflow-hidden rounded-[28px] border border-white/10 bg-[oklch(0.135_0.02_248/0.85)] shadow-2xl shadow-black/50 backdrop-blur-2xl">
+        <div className="surface-glass cinematic-divider relative overflow-hidden rounded-[28px]">
           <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
 
           {/* Tab bar */}
@@ -505,13 +505,112 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
           </div>
         </div>
 
-        <p className="text-center text-[11px] text-white/18">Powered by Gemini · YouTube · Kroger</p>
+        <p className="text-center text-[11px] text-white/25 lg:text-left">Powered by Gemini · YouTube · Kroger · Secure OAuth handoff</p>
+        </div>
       </div>
     </main>
   )
 }
 
 // ── Sub-components ─────────────────────────────────────────────────────────────
+
+function BrandStoryPanel({ variant }: { variant: "fresh" | "returning" }) {
+  const [tilt, setTilt] = useState({ x: 0, y: 0 })
+
+  function handleMove(event: React.MouseEvent<HTMLDivElement>) {
+    const rect = event.currentTarget.getBoundingClientRect()
+    const dx = (event.clientX - rect.left) / rect.width - 0.5
+    const dy = (event.clientY - rect.top) / rect.height - 0.5
+    setTilt({ x: dx * 6, y: dy * -5 })
+  }
+
+  function handleLeave() {
+    setTilt({ x: 0, y: 0 })
+  }
+
+  return (
+    <div className="relative order-1 flex flex-col justify-center lg:order-none">
+      <div className="pointer-events-none absolute inset-0 opacity-[0.07]">
+        <div
+          className="absolute inset-0"
+          style={{
+            backgroundImage: `linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px), linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px)`,
+            backgroundSize: "48px 48px",
+          }}
+        />
+      </div>
+      <div className="pointer-events-none absolute -left-12 -top-12 h-48 w-48 rounded-full bg-primary/20 blur-3xl animate-[cinematic-drift_8s_ease-in-out_infinite]" />
+      <div className="pointer-events-none absolute -bottom-10 right-0 h-40 w-40 rounded-full bg-emerald-400/15 blur-3xl animate-[cinematic-drift_10s_ease-in-out_infinite]" />
+
+      <div className="relative space-y-6 text-center lg:text-left" onMouseMove={handleMove} onMouseLeave={handleLeave}>
+        <div className="inline-flex flex-col items-center gap-4 lg:items-start">
+          <div className="relative inline-flex">
+            <div className="absolute inset-0 rounded-2xl bg-primary/35 blur-2xl animate-pulse" />
+            <div className="relative flex h-[78px] w-[78px] items-center justify-center rounded-2xl border border-primary/35 bg-gradient-to-br from-primary/30 via-primary/14 to-transparent shadow-2xl shadow-primary/15">
+              <ShoppingCart className="h-[34px] w-[34px] text-primary animate-[food-float_6s_ease-in-out_infinite]" />
+              <span className="absolute -right-2 -top-2 h-3 w-3 rounded-full bg-emerald-300 shadow-[0_0_18px_rgba(110,231,183,0.7)] animate-[orbit-slow_4s_linear_infinite]" />
+            </div>
+          </div>
+          <div>
+            <p className="text-[11px] font-medium uppercase tracking-[0.28em] text-primary/75">Your AI grocery agent</p>
+            {variant === "returning" ? (
+              <>
+                <h1 className="mt-3 text-balance text-[2rem] font-semibold leading-tight tracking-tight text-white md:text-[2.35rem]">
+                  Welcome back
+                </h1>
+                <p className="mt-3 max-w-md text-[15px] leading-relaxed text-white/48">
+                  Sign in to continue planning meals and building your Kroger cart.
+                </p>
+              </>
+            ) : (
+              <>
+                <h1 className="mt-3 bg-gradient-to-r from-white via-white to-white/55 bg-clip-text text-balance text-[2rem] font-semibold leading-tight tracking-tight text-transparent md:text-[2.45rem]">
+                  Crave it. Find it. Cart it.
+                </h1>
+                <p className="mt-3 max-w-md text-[15px] leading-relaxed text-white/48">
+                  A cinematic AI grocery flow: from craving to checkout in minutes, not hours.
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+
+        <ul
+          className="space-y-3 pt-2 transition-transform duration-300"
+          style={{ transform: `perspective(950px) rotateX(${tilt.y}deg) rotateY(${tilt.x}deg)` }}
+        >
+          {ONBOARDING_STEPS.map(({ icon: Icon, title, body, micro }, i) => (
+            <li
+              key={title}
+              className="group relative flex gap-3 overflow-hidden rounded-2xl border border-white/[0.07] bg-white/[0.035] px-4 py-3.5 text-left backdrop-blur-sm transition-colors hover:border-white/12 animate-[card-pop-in_500ms_ease-out_both]"
+              style={{ animationDelay: `${i * 120}ms` }}
+            >
+              <span className="pointer-events-none absolute inset-y-0 -left-20 w-16 bg-gradient-to-r from-transparent via-white/20 to-transparent opacity-0 group-hover:opacity-100 group-hover:animate-[spotlight-sweep_1000ms_ease-out]" />
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-white/10 bg-white/[0.06] text-[11px] font-semibold text-white/35">
+                {i + 1}
+              </span>
+              <span className="min-w-0">
+                <span className="flex items-center gap-2">
+                  <Icon className="h-4 w-4 shrink-0 text-primary/85" aria-hidden />
+                  <span className="text-[14px] font-medium text-white/88">{title}</span>
+                </span>
+                <span className="mt-1 block text-[13px] leading-relaxed text-white/45">{body}</span>
+                <span className="mt-1 block text-[11px] leading-relaxed text-white/30">{micro}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="space-y-2 border-t border-white/[0.06] pt-6">
+          <p className="text-[12px] leading-relaxed text-white/38">
+            <span className="font-medium text-white/55">Kroger</span> is a national supermarket chain with pickup and delivery — we connect so your cart matches real store inventory.
+          </p>
+          <p className="text-[11px] text-white/28">Your Kroger password never passes through CraveCart — OAuth keeps sign-in on Kroger&apos;s side.</p>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 function Field({ label, htmlFor, children }: { label: string; htmlFor: string; children: React.ReactNode }) {
   return (

--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, type FormEvent } from "react"
 import {
   createUserWithEmailAndPassword,
   getAuth,
-  sendPasswordResetEmail,
   signInWithEmailAndPassword,
   updateProfile,
 } from "firebase/auth"
@@ -14,6 +13,7 @@ import {
   getFirebaseBrowserApp,
   mapFirebaseAuthError,
   postFirebaseSessionCookie,
+  sendCravecartPasswordResetEmail,
   type LoadedFirebaseBrowserConfig,
 } from "@/lib/firebase/clientAuth"
 import { cn } from "@/lib/utils"
@@ -114,7 +114,7 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
           onAuthed?.(user)
         }
       } catch (err) {
-        setFormError(mapFirebaseAuthError(err))
+        setFormError(mapFirebaseAuthError(err, "signIn"))
       }
     } catch {
       setFormError("Network error. Try again.")
@@ -156,7 +156,7 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
           onAuthed?.(user)
         }
       } catch (err) {
-        setFormError(mapFirebaseAuthError(err))
+        setFormError(mapFirebaseAuthError(err, "signUp"))
       }
     } catch {
       setFormError("Network error. Try again.")
@@ -179,17 +179,10 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
       try {
         const auth = getAuth(getFirebaseBrowserApp(fbCfg))
         const origin =
-          typeof window !== "undefined" && window.location?.origin?.trim?.() ? window.location.origin : ""
-        if (origin) {
-          await sendPasswordResetEmail(auth, fpEmail.trim(), {
-            url: `${origin}/auth/reset-password`,
-            handleCodeInApp: false,
-          })
-        } else {
-          await sendPasswordResetEmail(auth, fpEmail.trim())
-        }
+          typeof window !== "undefined" && window.location?.origin?.trim?.() ? window.location.origin.trim() : ""
+        await sendCravecartPasswordResetEmail(auth, fpEmail.trim(), origin)
       } catch (err) {
-        setFormError(mapFirebaseAuthError(err))
+        setFormError(mapFirebaseAuthError(err, "passwordReset"))
         return
       }
       setFpDone(true)

--- a/components/LoginScreen.tsx
+++ b/components/LoginScreen.tsx
@@ -10,6 +10,7 @@ import {
 import { Eye, EyeOff, ShoppingCart } from "lucide-react"
 import {
   fetchFirebaseBrowserConfig,
+  FIREBASE_RESET_OUTLOOK_SAFELINKS_HINT,
   getFirebaseBrowserApp,
   mapFirebaseAuthError,
   postFirebaseSessionCookie,
@@ -252,6 +253,7 @@ export function LoginScreen({ onAuthed }: LoginScreenProps) {
                   <p className="text-[14px] leading-relaxed text-white/65">
                     If an account exists for that address, Firebase sent a reset link.
                   </p>
+                  <p className="text-[11px] leading-relaxed text-white/42">{FIREBASE_RESET_OUTLOOK_SAFELINKS_HINT}</p>
                   <button
                     type="button"
                     onClick={() => {

--- a/components/OnboardingOverlay.tsx
+++ b/components/OnboardingOverlay.tsx
@@ -1,0 +1,370 @@
+"use client"
+
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { useEffect, useMemo, useState } from "react"
+import {
+  ArrowLeft,
+  ArrowRight,
+  Loader2,
+  ShieldCheck,
+  ShoppingBag,
+  ShoppingCartIcon,
+  Truck,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogOverlay, DialogPortal } from "@/components/ui/dialog"
+import { startKrogerConnect } from "@/lib/kroger/clientStartConnect"
+import { ONBOARDING_STEPS } from "@/lib/onboarding/narrative"
+import { markFirstVisitTourSeen } from "@/lib/onboarding/state"
+import { cn } from "@/lib/utils"
+
+const FEATURE_LINES = ["Diet-aware cravings", "Paste recipe links", "One-click Kroger cart"] as const
+const DEMO_INGREDIENTS = [
+  ["Chicken breast", "1.5 lb", "Kroger boneless chicken"],
+  ["Heavy cream", "1 cup", "Private Selection heavy cream"],
+  ["Parmesan", "4 oz", "Kroger grated parmesan"],
+  ["Pasta", "16 oz", "Simple Truth linguine"],
+] as const
+
+const SCENES = ONBOARDING_STEPS.length
+
+interface OnboardingOverlayProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Called when mock Kroger mode connects without redirect */
+  onKrogerMockConnected: () => void
+}
+
+export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }: OnboardingOverlayProps) {
+  const [step, setStep] = useState(0)
+  const [connectBusy, setConnectBusy] = useState(false)
+  const [handoff, setHandoff] = useState(false)
+  const [connectErr, setConnectErr] = useState<string | null>(null)
+
+  function resetStep() {
+    setStep(0)
+    setConnectErr(null)
+    setConnectBusy(false)
+    setHandoff(false)
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) resetStep()
+    onOpenChange(next)
+  }
+
+  useEffect(() => {
+    if (open) setStep(0)
+  }, [open])
+
+  function goToStep(target: number) {
+    setStep(Math.max(0, Math.min(target, SCENES - 1)))
+  }
+
+  async function handleConnectKroger() {
+    setConnectBusy(true)
+    setHandoff(true)
+    setConnectErr(null)
+    try {
+      const result = await startKrogerConnect()
+      if (result.kind === "mock") {
+        onKrogerMockConnected()
+        handleOpenChange(false)
+        return
+      }
+      if (result.kind === "redirect") {
+        markFirstVisitTourSeen(window.localStorage)
+        return
+      }
+      if (result.kind === "unauthorized") {
+        setHandoff(false)
+        setConnectErr("Sign in to CraveCart first, then try again.")
+        return
+      }
+      setHandoff(false)
+      setConnectErr(result.message ?? "Could not start Kroger connection.")
+    } finally {
+      setConnectBusy(false)
+    }
+  }
+
+  function goNext() {
+    goToStep(step + 1)
+  }
+
+  function goBack() {
+    goToStep(step - 1)
+  }
+
+  const stepLabel = useMemo(() => `${step + 1} of ${SCENES}`, [step])
+  const StepTwoIcon = ONBOARDING_STEPS[1].icon
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        <DialogOverlay className="bg-black/85 backdrop-blur-xl" />
+        <DialogPrimitive.Content
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+          className="fixed inset-0 z-50 flex h-[100dvh] max-h-[100dvh] flex-col overflow-hidden outline-none transition-opacity duration-200 data-[state=closed]:opacity-0 data-[state=open]:opacity-100"
+          aria-describedby={undefined}
+        >
+          <DialogPrimitive.Title className="sr-only">CraveCart onboarding tour</DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Three steps: welcome to CraveCart, learn about Kroger, connect your account or skip.
+          </DialogPrimitive.Description>
+          <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
+            <div className="absolute -left-1/4 top-0 h-[min(70vh,520px)] w-[min(90vw,720px)] rounded-full bg-primary/12 blur-[120px] animate-[cinematic-drift_8s_ease-in-out_infinite]" />
+            <div className="absolute -right-1/4 bottom-0 h-[min(60vh,440px)] w-[min(85vw,640px)] rounded-full bg-emerald-500/10 blur-[100px] animate-[cinematic-drift_11s_ease-in-out_infinite]" />
+            <div className="absolute -top-20 left-1/3 h-48 w-48 rounded-full bg-sky-400/10 blur-3xl animate-[cinematic-drift_9s_ease-in-out_infinite]" />
+          </div>
+
+          <div className="relative z-10 flex min-h-0 flex-1 flex-col pointer-events-auto">
+            <header className="flex shrink-0 items-center justify-between gap-3 px-4 py-3 sm:px-8 sm:py-4">
+              <div className="flex min-w-0 items-center gap-2">
+                {Array.from({ length: SCENES }).map((_, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => goToStep(i)}
+                    className={cn(
+                      "h-1.5 shrink-0 rounded-full transition-all duration-300",
+                      i === step ? "w-8 bg-primary" : i < step ? "w-2 bg-white/35" : "w-2 bg-white/12",
+                    )}
+                    aria-label={`Jump to step ${i + 1}`}
+                  />
+                ))}
+                <span className="ml-2 truncate text-[11px] uppercase tracking-[0.2em] text-white/40">{stepLabel}</span>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => handleOpenChange(false)}
+                  className="text-[13px] font-medium text-white/45 transition-colors hover:text-white/75"
+                >
+                  Skip tour
+                </button>
+                <DialogPrimitive.Close
+                  className="rounded-lg p-2 text-white/45 transition-colors hover:bg-white/10 hover:text-white"
+                  aria-label="Close"
+                >
+                  <span className="sr-only">Close</span>
+                  <span aria-hidden className="text-lg leading-none">
+                    ×
+                  </span>
+                </DialogPrimitive.Close>
+              </div>
+            </header>
+
+            {/* One step at a time — fills space between header and footer (no vertical tour scroll) */}
+            <div className="relative mx-auto flex min-h-0 w-full max-w-5xl flex-1 flex-col px-4 sm:px-8">
+              <div
+                key={step}
+                className="reveal-up flex min-h-0 flex-1 flex-col items-center justify-center py-1"
+                role="tabpanel"
+                aria-live="polite"
+              >
+                {step === 0 ? (
+                  <div className="mx-auto flex w-full max-w-xl flex-col items-center text-center">
+                    <div className="relative mb-3 inline-flex sm:mb-5">
+                      <div className="absolute inset-0 rounded-[22px] bg-primary/25 blur-xl animate-pulse sm:rounded-[28px] sm:blur-2xl" />
+                      <div className="relative flex h-[68px] w-[68px] items-center justify-center rounded-[22px] border border-primary/35 bg-gradient-to-br from-primary/35 via-primary/15 to-transparent shadow-xl shadow-primary/15 sm:h-[88px] sm:w-[88px] sm:rounded-[28px] sm:shadow-2xl">
+                        <ShoppingCartIcon
+                          className="h-9 w-9 text-primary animate-[food-float_5s_ease-in-out_infinite] sm:h-11 sm:w-11"
+                          strokeWidth={1.25}
+                        />
+                      </div>
+                    </div>
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-primary/80 sm:text-[11px] sm:tracking-[0.35em]">
+                      Step 1
+                    </p>
+                    <h2 className="mt-1.5 max-w-lg text-balance text-xl font-semibold leading-snug tracking-tight text-white sm:mt-2 sm:max-w-xl sm:text-3xl">
+                      {ONBOARDING_STEPS[0].title}
+                    </h2>
+                    <p className="mx-auto mt-2 max-w-md text-[13px] leading-snug text-white/50 sm:mt-3 sm:max-w-lg sm:text-[15px] sm:leading-relaxed">
+                      {ONBOARDING_STEPS[0].body}
+                    </p>
+                    <div className="mt-3 flex max-w-lg flex-wrap justify-center gap-1.5 sm:mt-5 sm:gap-2">
+                      {FEATURE_LINES.map((line) => (
+                        <span
+                          key={line}
+                          className="rounded-full border border-white/10 bg-white/[0.06] px-2.5 py-1 text-[10px] text-white/55 sm:px-4 sm:py-2 sm:text-[12px]"
+                        >
+                          {line}
+                        </span>
+                      ))}
+                    </div>
+                    <div className="mt-3 w-full max-w-lg rounded-xl border border-white/10 bg-white/[0.04] p-3 text-left surface-glass-soft sm:mt-4 sm:max-w-xl sm:rounded-2xl sm:p-4">
+                      <p className="text-[10px] uppercase tracking-wider text-white/35 sm:text-xs">Micro Demo</p>
+                      <div className="mt-2 space-y-1.5 text-[11px] sm:mt-3 sm:space-y-2 sm:text-[13px]">
+                        <p className="rounded-xl bg-white/[0.06] px-2.5 py-1.5 text-white/75 sm:rounded-2xl sm:px-3 sm:py-2">
+                          I want a high-protein chicken pasta dinner
+                        </p>
+                        <p className="rounded-xl bg-primary/14 px-2.5 py-1.5 text-primary/90 sm:rounded-2xl sm:px-3 sm:py-2">
+                          Got it. Parsing recipe intent and dietary goals…
+                        </p>
+                        <p className="rounded-xl bg-white/[0.06] px-2.5 py-1.5 text-white/60 sm:rounded-2xl sm:px-3 sm:py-2">
+                          {ONBOARDING_STEPS[0].micro}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ) : null}
+
+                {step === 1 ? (
+                  <div className="mx-auto w-full max-w-3xl text-center lg:text-left">
+                    <div className="mb-2 inline-flex rounded-xl border border-white/10 bg-white/[0.05] p-2.5 sm:mb-3 sm:rounded-2xl sm:p-4">
+                      <StepTwoIcon
+                        className="h-8 w-8 text-amber-300/90 animate-[food-float_5s_ease-in-out_infinite] sm:h-10 sm:w-10"
+                        strokeWidth={1.25}
+                      />
+                    </div>
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-primary/80 sm:text-[11px] sm:tracking-[0.35em]">
+                      Step 2
+                    </p>
+                    <h2 className="mt-1 text-balance text-xl font-semibold leading-snug tracking-tight text-white sm:mt-2 sm:text-3xl lg:text-4xl">
+                      {ONBOARDING_STEPS[1].title}
+                    </h2>
+                    <p className="mt-2 text-[13px] leading-snug text-white/52 sm:mt-3 sm:text-[15px] sm:leading-relaxed">
+                      {ONBOARDING_STEPS[1].body}
+                    </p>
+                    <div className="mx-auto mt-3 w-full overflow-hidden rounded-xl border border-white/10 bg-white/[0.04] sm:mt-4 sm:rounded-2xl lg:mx-0">
+                      <div className="grid grid-cols-[1.35fr_0.6fr_1.5fr] border-b border-white/10 px-2 py-1.5 text-[9px] uppercase tracking-[0.12em] text-white/35 sm:px-4 sm:py-2 sm:text-[11px] sm:tracking-[0.16em]">
+                        <span>Ingredient</span>
+                        <span className="text-center">Qty</span>
+                        <span className="min-w-0 truncate sm:overflow-visible sm:whitespace-normal">Kroger match</span>
+                      </div>
+                      <ul>
+                        {DEMO_INGREDIENTS.map(([name, qty, mapped]) => (
+                          <li
+                            key={name}
+                            className="grid grid-cols-[1.35fr_0.6fr_1.5fr] border-b border-white/[0.06] px-2 py-[5px] text-[10px] leading-tight text-white/65 last:border-b-0 sm:px-4 sm:py-2 sm:text-[13px] sm:leading-snug"
+                          >
+                            <span className="break-words pr-1">{name}</span>
+                            <span className="text-center tabular-nums">{qty}</span>
+                            <span className="min-w-0 break-words text-emerald-300/85">{mapped}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="mt-2 flex items-start gap-2 rounded-xl border border-white/10 bg-white/[0.035] px-3 py-2.5 text-left sm:mt-3 sm:gap-3 sm:rounded-2xl sm:px-4 sm:py-3">
+                      <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-sky-400/90 sm:h-5 sm:w-5" />
+                      <p className="text-[11px] leading-snug text-white/58 sm:text-[13px] sm:leading-relaxed">{ONBOARDING_STEPS[1].micro}</p>
+                    </div>
+                  </div>
+                ) : null}
+
+                {step === 2 ? (
+                  <div className="mx-auto flex w-full max-w-md flex-col gap-3 text-center sm:max-w-lg sm:gap-4">
+                    <div className="shrink-0">
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.3em] text-primary/80 sm:text-[11px] sm:tracking-[0.35em]">
+                        Step 3
+                      </p>
+                      <h2 className="mt-2 text-balance text-xl font-semibold leading-snug tracking-tight text-white sm:text-3xl">
+                        {ONBOARDING_STEPS[2].title}
+                      </h2>
+                      <p className="mx-auto mt-2 max-w-md text-[13px] leading-snug text-white/50 sm:mt-3 sm:text-[15px]">
+                        {ONBOARDING_STEPS[2].body}
+                      </p>
+                    </div>
+                    <div className="flex w-full flex-col gap-2.5 text-left sm:gap-3">
+                      <div className="flex items-start gap-2 rounded-xl border border-white/10 bg-white/[0.04] p-3 sm:rounded-2xl sm:gap-3 sm:p-4">
+                        <Truck className="mt-0.5 h-4 w-4 shrink-0 text-amber-300/90 sm:h-5 sm:w-5" />
+                        <p className="text-[12px] leading-snug text-white/60 sm:text-[14px] sm:leading-relaxed">{ONBOARDING_STEPS[2].micro}</p>
+                      </div>
+                      <div className="rounded-xl border border-white/10 bg-black/35 px-3 py-2.5 sm:rounded-2xl sm:px-4 sm:py-3">
+                        <p className="text-[10px] uppercase tracking-wider text-white/35 sm:text-[11px]">Micro Demo</p>
+                        <div className="mt-1.5 space-y-1.5 text-[11px] text-white/62 sm:mt-2 sm:space-y-2 sm:text-[13px]">
+                          <p className="flex items-center justify-between gap-2 rounded-lg bg-white/[0.05] px-2 py-1.5 sm:px-3 sm:py-2">
+                            <span className="truncate">Pickup location selected</span>
+                            <span className="shrink-0 text-emerald-300">Done</span>
+                          </p>
+                          <p className="flex items-center justify-between gap-2 rounded-lg bg-white/[0.05] px-2 py-1.5 sm:px-3 sm:py-2">
+                            <span className="truncate">Delivery window</span>
+                            <span className="shrink-0 text-emerald-300">Done</span>
+                          </p>
+                          <p className="flex items-center justify-between gap-2 rounded-lg bg-white/[0.05] px-2 py-1.5 sm:px-3 sm:py-2">
+                            <span className="truncate">Checkout handoff</span>
+                            <span className="shrink-0 text-primary">Ready</span>
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                    {connectErr ? (
+                      <p className="rounded-xl border border-rose-500/25 bg-rose-500/10 px-3 py-2 text-left text-[12px] text-rose-200/90 sm:px-4 sm:py-3 sm:text-[13px]">
+                        {connectErr}
+                      </p>
+                    ) : null}
+                    <div className="flex flex-col items-center gap-2 pt-1 sm:gap-3 sm:pt-2">
+                      <Button
+                        type="button"
+                        size="xl"
+                        variant="cinematic"
+                        disabled={connectBusy}
+                        onClick={() => void handleConnectKroger()}
+                        className="relative z-10 h-11 w-full max-w-[280px] text-sm sm:h-12 sm:text-base"
+                      >
+                        {connectBusy ? (
+                          <>
+                            <Loader2 className="h-5 w-5 animate-spin" />
+                            {handoff ? "Preparing secure handoff…" : "Opening Kroger…"}
+                          </>
+                        ) : (
+                          <>
+                            <ShoppingBag className="h-5 w-5" />
+                            Connect Kroger account
+                          </>
+                        )}
+                      </Button>
+                      <button
+                        type="button"
+                        onClick={() => handleOpenChange(false)}
+                        className="text-[12px] text-white/40 underline-offset-4 transition-colors hover:text-white/65 hover:underline sm:text-[13px]"
+                      >
+                        I&apos;ll do this later
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+
+            <footer className="surface-glass-soft flex shrink-0 items-center justify-between gap-3 border-t border-white/[0.08] px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] sm:gap-4 sm:px-8 sm:pt-4">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={step === 0}
+                onClick={goBack}
+                className="rounded-full border-white/15 bg-white/[0.04] text-white/85 hover:bg-white/10"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                Back
+              </Button>
+              {step < SCENES - 1 ? (
+                <Button
+                  type="button"
+                  onClick={goNext}
+                  variant="secondary"
+                  className="rounded-full bg-white/[0.08] px-6 text-white hover:bg-white/14"
+                >
+                  Next
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => handleOpenChange(false)}
+                  className="rounded-full bg-white/[0.08] px-6 text-white hover:bg-white/14"
+                >
+                  Finish tour
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              )}
+            </footer>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  )
+}

--- a/components/OnboardingOverlay.tsx
+++ b/components/OnboardingOverlay.tsx
@@ -29,8 +29,6 @@ const DEMO_INGREDIENTS = [
 interface OnboardingOverlayProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  /** Called when mock Kroger mode connects without redirect */
-  onKrogerMockConnected: () => void
   /** When false (tour above login), step 3 is informational — no Kroger OAuth until signed in. */
   signedIn: boolean
 }
@@ -38,7 +36,6 @@ interface OnboardingOverlayProps {
 export function OnboardingOverlay({
   open,
   onOpenChange,
-  onKrogerMockConnected,
   signedIn,
 }: OnboardingOverlayProps) {
   const [step, setStep] = useState(0)
@@ -75,11 +72,6 @@ export function OnboardingOverlay({
     setConnectErr(null)
     try {
       const result = await startKrogerConnect()
-      if (result.kind === "mock") {
-        onKrogerMockConnected()
-        handleOpenChange(false)
-        return
-      }
       if (result.kind === "redirect") {
         markFirstVisitTourSeen(window.localStorage)
         return

--- a/components/OnboardingOverlay.tsx
+++ b/components/OnboardingOverlay.tsx
@@ -26,20 +26,28 @@ const DEMO_INGREDIENTS = [
   ["Pasta", "16 oz", "Simple Truth linguine"],
 ] as const
 
-const SCENES = ONBOARDING_STEPS.length
-
 interface OnboardingOverlayProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   /** Called when mock Kroger mode connects without redirect */
   onKrogerMockConnected: () => void
+  /** When false (tour above login), step 3 is informational — no Kroger OAuth until signed in. */
+  signedIn: boolean
 }
 
-export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }: OnboardingOverlayProps) {
+export function OnboardingOverlay({
+  open,
+  onOpenChange,
+  onKrogerMockConnected,
+  signedIn,
+}: OnboardingOverlayProps) {
   const [step, setStep] = useState(0)
   const [connectBusy, setConnectBusy] = useState(false)
   const [handoff, setHandoff] = useState(false)
   const [connectErr, setConnectErr] = useState<string | null>(null)
+
+  const stepCount = ONBOARDING_STEPS.length
+  const maxStepIndex = stepCount - 1
 
   function resetStep() {
     setStep(0)
@@ -58,7 +66,7 @@ export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }:
   }, [open])
 
   function goToStep(target: number) {
-    setStep(Math.max(0, Math.min(target, SCENES - 1)))
+    setStep(Math.max(0, Math.min(target, maxStepIndex)))
   }
 
   async function handleConnectKroger() {
@@ -96,7 +104,7 @@ export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }:
     goToStep(step - 1)
   }
 
-  const stepLabel = useMemo(() => `${step + 1} of ${SCENES}`, [step])
+  const stepLabel = useMemo(() => `${step + 1} of ${stepCount}`, [step, stepCount])
   const StepTwoIcon = ONBOARDING_STEPS[1].icon
 
   return (
@@ -111,7 +119,8 @@ export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }:
         >
           <DialogPrimitive.Title className="sr-only">CraveCart onboarding tour</DialogPrimitive.Title>
           <DialogPrimitive.Description className="sr-only">
-            Three steps: welcome to CraveCart, learn about Kroger, connect your account or skip.
+            Three steps: welcome to CraveCart, Kroger-aware shopping, pickup and checkout on Kroger. Connect Kroger
+            from the signed-in app when you&apos;re ready.
           </DialogPrimitive.Description>
           <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden">
             <div className="absolute -left-1/4 top-0 h-[min(70vh,520px)] w-[min(90vw,720px)] rounded-full bg-primary/12 blur-[120px] animate-[cinematic-drift_8s_ease-in-out_infinite]" />
@@ -122,7 +131,7 @@ export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }:
           <div className="relative z-10 flex min-h-0 flex-1 flex-col pointer-events-auto">
             <header className="flex shrink-0 items-center justify-between gap-3 px-4 py-3 sm:px-8 sm:py-4">
               <div className="flex min-w-0 items-center gap-2">
-                {Array.from({ length: SCENES }).map((_, i) => (
+                {Array.from({ length: stepCount }).map((_, i) => (
                   <button
                     key={i}
                     type="button"
@@ -290,39 +299,49 @@ export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }:
                         </div>
                       </div>
                     </div>
-                    {connectErr ? (
+                    {signedIn && connectErr ? (
                       <p className="rounded-xl border border-rose-500/25 bg-rose-500/10 px-3 py-2 text-left text-[12px] text-rose-200/90 sm:px-4 sm:py-3 sm:text-[13px]">
                         {connectErr}
                       </p>
                     ) : null}
                     <div className="flex flex-col items-center gap-2 pt-1 sm:gap-3 sm:pt-2">
-                      <Button
-                        type="button"
-                        size="xl"
-                        variant="cinematic"
-                        disabled={connectBusy}
-                        onClick={() => void handleConnectKroger()}
-                        className="relative z-10 h-11 w-full max-w-[280px] text-sm sm:h-12 sm:text-base"
-                      >
-                        {connectBusy ? (
-                          <>
-                            <Loader2 className="h-5 w-5 animate-spin" />
-                            {handoff ? "Preparing secure handoff…" : "Opening Kroger…"}
-                          </>
-                        ) : (
-                          <>
-                            <ShoppingBag className="h-5 w-5" />
-                            Connect Kroger account
-                          </>
-                        )}
-                      </Button>
-                      <button
-                        type="button"
-                        onClick={() => handleOpenChange(false)}
-                        className="text-[12px] text-white/40 underline-offset-4 transition-colors hover:text-white/65 hover:underline sm:text-[13px]"
-                      >
-                        I&apos;ll do this later
-                      </button>
+                      {signedIn ? (
+                        <>
+                          <Button
+                            type="button"
+                            size="xl"
+                            variant="cinematic"
+                            disabled={connectBusy}
+                            onClick={() => void handleConnectKroger()}
+                            className="relative z-10 h-11 w-full max-w-[280px] text-sm sm:h-12 sm:text-base"
+                          >
+                            {connectBusy ? (
+                              <>
+                                <Loader2 className="h-5 w-5 animate-spin" />
+                                {handoff ? "Preparing secure handoff…" : "Opening Kroger…"}
+                              </>
+                            ) : (
+                              <>
+                                <ShoppingBag className="h-5 w-5" />
+                                Connect Kroger account
+                              </>
+                            )}
+                          </Button>
+                          <button
+                            type="button"
+                            onClick={() => handleOpenChange(false)}
+                            className="text-[12px] text-white/40 underline-offset-4 transition-colors hover:text-white/65 hover:underline sm:text-[13px]"
+                          >
+                            I&apos;ll do this later
+                          </button>
+                        </>
+                      ) : (
+                        <p className="max-w-xs text-[12px] leading-relaxed text-white/42 sm:max-w-md sm:text-[13px]">
+                          When you&apos;re ready, sign in to CraveCart — then you can link Kroger from the header or
+                          prompt for cart and checkout. Use <span className="text-white/55">Finish tour</span> below to
+                          keep exploring.
+                        </p>
+                      )}
                     </div>
                   </div>
                 ) : null}
@@ -340,7 +359,7 @@ export function OnboardingOverlay({ open, onOpenChange, onKrogerMockConnected }:
                 <ArrowLeft className="h-4 w-4" />
                 Back
               </Button>
-              {step < SCENES - 1 ? (
+              {step < maxStepIndex ? (
                 <Button
                   type="button"
                   onClick={goNext}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -84,7 +84,7 @@ export function Sidebar({
       <aside
         className={cn(
           "fixed inset-y-0 left-0 z-30 flex w-[260px] flex-col",
-          "border-r border-white/[0.07] bg-[oklch(0.12_0.018_248)]",
+          "border-r border-white/[0.07] bg-[oklch(0.12_0.018_248/0.92)] backdrop-blur-xl",
           "transition-transform duration-300 ease-in-out",
           "md:relative md:inset-auto md:z-auto md:translate-x-0",
           isOpen ? "translate-x-0" : "-translate-x-full"
@@ -116,7 +116,7 @@ export function Sidebar({
           <button
             onClick={onNewChat}
             className={cn(
-              "group flex w-full items-center gap-2.5 rounded-xl border border-white/8 bg-white/[0.04]",
+              "group interactive-shimmer flex w-full items-center gap-2.5 rounded-xl border border-white/8 bg-white/[0.04]",
               "px-3 py-2.5 text-sm text-white/60 transition-all duration-150",
               "hover:border-primary/25 hover:bg-primary/8 hover:text-white",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50"
@@ -173,7 +173,7 @@ export function Sidebar({
                             onClick={() => onSelectSession(session.id)}
                             aria-current={isActive ? "page" : undefined}
                             className={cn(
-                              "group relative flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-left text-[13px]",
+                              "group interactive-shimmer relative flex w-full items-center gap-2.5 rounded-xl px-3 py-2 text-left text-[13px]",
                               "border-l-2 transition-all duration-150",
                               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50",
                               isActive
@@ -204,7 +204,7 @@ export function Sidebar({
 
         {/* User profile block */}
         <div className="p-3">
-          <div className="group flex items-center gap-3 rounded-xl px-2.5 py-2.5 transition-colors hover:bg-white/[0.05]">
+          <div className="group interactive-shimmer flex items-center gap-3 rounded-xl px-2.5 py-2.5 transition-colors hover:bg-white/[0.05]">
             {/* Avatar */}
             <div className="relative shrink-0">
               <div className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-primary/40 to-primary/15 text-[12px] font-bold text-primary shadow-inner shadow-primary/10 ring-1 ring-primary/20">

--- a/components/VideoResultCard.tsx
+++ b/components/VideoResultCard.tsx
@@ -16,7 +16,7 @@ export function VideoResultCard({ video }: VideoResultCardProps) {
           : "Transcript unavailable"
   const sourceLabel =
     video.recipeSource === "none"
-      ? "video metadata"
+      ? "unknown"
       : video.recipeSource.replace("_", " ")
 
   return (

--- a/components/VideoResultCard.tsx
+++ b/components/VideoResultCard.tsx
@@ -6,6 +6,19 @@ interface VideoResultCardProps {
 }
 
 export function VideoResultCard({ video }: VideoResultCardProps) {
+  const transcriptLabel =
+    video.transcriptAvailable
+      ? "Transcript available"
+      : video.transcriptStatus === "blocked"
+        ? "Transcript fetch blocked"
+        : video.transcriptStatus === "error"
+          ? "Transcript fetch failed"
+          : "Transcript unavailable"
+  const sourceLabel =
+    video.recipeSource === "none"
+      ? "video metadata"
+      : video.recipeSource.replace("_", " ")
+
   return (
     <section className="rounded-[28px] border border-white/12 bg-white/[0.06] px-5 py-4 text-white backdrop-blur-xl">
       <div className="flex items-center gap-2 text-sm uppercase tracking-[0.24em] text-primary/80">
@@ -24,7 +37,7 @@ export function VideoResultCard({ video }: VideoResultCardProps) {
       <p className="mt-1 text-sm text-white/65">{video.video.channel}</p>
       <p className="mt-4 text-sm leading-7 text-white/80">{video.summary}</p>
       <p className="mt-3 text-xs uppercase tracking-[0.2em] text-white/45">
-        {video.transcriptAvailable ? "Transcript available" : "Transcript unavailable"} · source {video.recipeSource.replace("_", " ")}
+        {transcriptLabel} · source {sourceLabel}
       </p>
     </section>
   )

--- a/components/WelcomeHero.tsx
+++ b/components/WelcomeHero.tsx
@@ -35,10 +35,11 @@ const CATEGORIES = [
 
 interface WelcomeHeroProps {
   onSelectCategory: (query: string) => void
-  krogerConnected: boolean
+  /** When false, chips are gated (logged-out previews). Signed-in users can chat either way — link Kroger for cart. */
+  agentChatEnabled: boolean
 }
 
-export function WelcomeHero({ onSelectCategory, krogerConnected }: WelcomeHeroProps) {
+export function WelcomeHero({ onSelectCategory, agentChatEnabled }: WelcomeHeroProps) {
   return (
     <div className="relative w-full max-w-3xl">
       {/* ── Floating food emojis (desktop only) ─────────────────────────── */}
@@ -89,6 +90,14 @@ export function WelcomeHero({ onSelectCategory, krogerConnected }: WelcomeHeroPr
           <p className="mx-auto max-w-sm text-[14px] leading-relaxed text-white/38">
             Describe a dish, paste a video link, or just say "buy groceries" — the agent handles everything live.
           </p>
+          <div className="surface-glass-soft mx-auto mt-3 max-w-xl rounded-2xl px-4 py-3 text-left">
+            <p className="text-[10px] uppercase tracking-[0.2em] text-white/35">Live flow preview</p>
+            <div className="mt-2 grid grid-cols-1 gap-2 text-[12px] text-white/60 sm:grid-cols-3">
+              <p className="rounded-lg bg-white/[0.04] px-3 py-2">1. Describe craving</p>
+              <p className="rounded-lg bg-white/[0.04] px-3 py-2">2. AI builds cart</p>
+              <p className="rounded-lg bg-white/[0.04] px-3 py-2">3. Checkout on Kroger</p>
+            </div>
+          </div>
         </div>
 
         {/* Stat labels — informational only, not interactive */}
@@ -123,12 +132,12 @@ export function WelcomeHero({ onSelectCategory, krogerConnected }: WelcomeHeroPr
                 key={cat.label}
                 type="button"
                 onClick={() => onSelectCategory(cat.query)}
-                disabled={!krogerConnected}
-                title={krogerConnected ? cat.query : "Connect Kroger first"}
+                disabled={!agentChatEnabled}
+                title={agentChatEnabled ? cat.query : "Sign in to use quick picks"}
                 className={cn(
                   "flex shrink-0 items-center gap-2 rounded-full border px-4 py-2 text-[13px] font-medium",
                   "transition-all duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50",
-                  krogerConnected
+                  agentChatEnabled
                     ? [
                         "border-white/10 bg-white/[0.05] text-white/60",
                         "hover:border-primary/35 hover:bg-primary/10 hover:text-white/90",
@@ -143,9 +152,11 @@ export function WelcomeHero({ onSelectCategory, krogerConnected }: WelcomeHeroPr
             ))}
           </div>
 
-          {!krogerConnected && (
-            <p className="mt-2 text-[11px] text-white/20">
-              Connect Kroger above to use quick picks
+          {!agentChatEnabled ? (
+            <p className="mt-2 text-[11px] text-white/20">Sign in to use quick picks.</p>
+          ) : (
+            <p className="mt-2 text-[11px] text-white/28">
+              Link Kroger (top-right) whenever you&apos;re ready for live cart — chat works either way.
             </p>
           )}
         </div>

--- a/components/WelcomeHero.tsx
+++ b/components/WelcomeHero.tsx
@@ -16,12 +16,6 @@ const FLOATERS = [
   { emoji: "🫕", style: { top: "12%",  right: "44%", fontSize: "1.6rem", animationDuration: "7.1s", animationDelay: "3.5s" } },
 ]
 
-const STATS = [
-  { icon: "🎬", label: "Recipe videos" },
-  { icon: "🛒", label: "Live cart writes" },
-  { icon: "⚡", label: "Gemini powered" },
-]
-
 const CATEGORIES = [
   { emoji: "🍕", label: "Pizza",    query: "Find a homemade pizza recipe video and buy the groceries" },
   { emoji: "🍔", label: "Burgers",  query: "Find a smash burger recipe video and buy the ingredients" },
@@ -53,7 +47,7 @@ export function WelcomeHero({ onSelectCategory, agentChatEnabled }: WelcomeHeroP
             className="absolute select-none"
             style={{
               ...f.style,
-              opacity: 0.09,
+              opacity: 0.055,
               animation: `food-float ${f.style.animationDuration} ease-in-out ${f.style.animationDelay} infinite`,
             }}
           >
@@ -63,70 +57,39 @@ export function WelcomeHero({ onSelectCategory, agentChatEnabled }: WelcomeHeroP
       </div>
 
       {/* ── Main content ─────────────────────────────────────────────────── */}
-      <div className="relative flex flex-col items-center gap-8 py-10 text-center">
+      <div className="relative flex flex-col items-center gap-7 py-6 text-center md:gap-8 md:py-8">
 
-        {/* Tagline */}
-        <div className="space-y-3" style={{ animation: "fade-in-up 0.55s ease-out both" }}>
-          <p className="text-[10px] uppercase tracking-[0.32em] text-white/28">
+        {/* Tagline — single focal block */}
+        <div className="max-w-xl space-y-2.5" style={{ animation: "fade-in-up 0.55s ease-out both" }}>
+          <p className="text-[10px] uppercase tracking-[0.3em] text-white/26">
             Your personal food agent
           </p>
 
-          <h2 className="text-[2.6rem] font-bold leading-[1.12] tracking-tight md:text-[3.2rem]">
-            <span className="bg-gradient-to-r from-white via-white/95 to-white/70 bg-clip-text text-transparent">
+          <h2 className="text-balance text-[clamp(2rem,6vw,2.85rem)] font-bold leading-[1.08] tracking-tight">
+            <span className="bg-gradient-to-r from-white via-white/95 to-white/75 bg-clip-text text-transparent">
               From craving
-            </span>
-            <br />
-            <span className="bg-gradient-to-br from-primary via-primary/85 to-primary/55 bg-clip-text text-transparent">
+            </span>{" "}
+            <span className="bg-gradient-to-br from-primary via-primary/88 to-primary/55 bg-clip-text text-transparent">
               to cart
             </span>
-            <span
-              className="text-white/38"
-              style={{ fontWeight: 300 }}
-            >
-              {" "}— in seconds.
+            <span className="text-white/34" style={{ fontWeight: 400 }}>
+              {" "}
+              — in seconds.
             </span>
           </h2>
 
-          <p className="mx-auto max-w-sm text-[14px] leading-relaxed text-white/38">
-            Describe a dish, paste a video link, or just say "buy groceries" — the agent handles everything live.
+          <p className="mx-auto max-w-md text-[13px] leading-relaxed text-white/36 md:text-[14px]">
+            Describe a craving or paste a link — recipes, carts, and checkout stay threaded in chat.
           </p>
-          <div className="surface-glass-soft mx-auto mt-3 max-w-xl rounded-2xl px-4 py-3 text-left">
-            <p className="text-[10px] uppercase tracking-[0.2em] text-white/35">Live flow preview</p>
-            <div className="mt-2 grid grid-cols-1 gap-2 text-[12px] text-white/60 sm:grid-cols-3">
-              <p className="rounded-lg bg-white/[0.04] px-3 py-2">1. Describe craving</p>
-              <p className="rounded-lg bg-white/[0.04] px-3 py-2">2. AI builds cart</p>
-              <p className="rounded-lg bg-white/[0.04] px-3 py-2">3. Checkout on Kroger</p>
-            </div>
-          </div>
         </div>
 
-        {/* Stat labels — informational only, not interactive */}
-        <div
-          className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1"
-          style={{ animation: "fade-in-up 0.55s ease-out 0.14s both" }}
-          aria-label="Agent capabilities"
-        >
-          {STATS.map((s, i) => (
-            <span key={s.label} className="flex items-center gap-1.5 select-none">
-              <span className="text-[12px] leading-none" aria-hidden="true">{s.icon}</span>
-              <span className="text-[11px] text-white/30">{s.label}</span>
-              {i < STATS.length - 1 && (
-                <span className="ml-4 text-white/12 text-[10px]" aria-hidden="true">·</span>
-              )}
-            </span>
-          ))}
-        </div>
-
-        {/* Category chips — horizontal scroll */}
-        <div
-          className="w-full"
-          style={{ animation: "fade-in-up 0.55s ease-out 0.26s both" }}
-        >
-          <p className="mb-3 text-[10px] uppercase tracking-[0.22em] text-white/22">
-            Quick picks
+        {/* Category chips */}
+        <div className="w-full max-w-2xl" style={{ animation: "fade-in-up 0.55s ease-out 0.12s both" }}>
+          <p className="mb-2.5 text-center text-[10px] uppercase tracking-[0.2em] text-white/26">
+            Try a craving
           </p>
 
-          <div className="scrollbar-none flex gap-2 overflow-x-auto pb-0.5">
+          <div className="scrollbar-none mx-auto flex max-w-full gap-2 overflow-x-auto px-1 pb-1 md:flex-wrap md:justify-center md:overflow-visible md:pb-0">
             {CATEGORIES.map((cat) => (
               <button
                 key={cat.label}
@@ -135,15 +98,15 @@ export function WelcomeHero({ onSelectCategory, agentChatEnabled }: WelcomeHeroP
                 disabled={!agentChatEnabled}
                 title={agentChatEnabled ? cat.query : "Sign in to use quick picks"}
                 className={cn(
-                  "flex shrink-0 items-center gap-2 rounded-full border px-4 py-2 text-[13px] font-medium",
-                  "transition-all duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/50",
+                  "flex shrink-0 items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-[12.5px] font-medium md:px-3.5 md:py-2",
+                  "transition-all duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary/45",
                   agentChatEnabled
                     ? [
-                        "border-white/10 bg-white/[0.05] text-white/60",
-                        "hover:border-primary/35 hover:bg-primary/10 hover:text-white/90",
-                        "active:scale-95",
+                        "border-white/[0.09] bg-white/[0.04] text-white/58",
+                        "hover:border-primary/32 hover:bg-primary/[0.09] hover:text-white/88",
+                        "active:scale-[0.98]",
                       ].join(" ")
-                    : "cursor-not-allowed border-white/[0.05] bg-white/[0.02] text-white/20"
+                    : "cursor-not-allowed border-white/[0.05] bg-white/[0.02] text-white/22"
                 )}
               >
                 <span aria-hidden="true">{cat.emoji}</span>
@@ -153,12 +116,8 @@ export function WelcomeHero({ onSelectCategory, agentChatEnabled }: WelcomeHeroP
           </div>
 
           {!agentChatEnabled ? (
-            <p className="mt-2 text-[11px] text-white/20">Sign in to use quick picks.</p>
-          ) : (
-            <p className="mt-2 text-[11px] text-white/28">
-              Link Kroger (top-right) whenever you&apos;re ready for live cart — chat works either way.
-            </p>
-          )}
+            <p className="mt-2 text-center text-[11px] text-white/22">Sign in to use cravings.</p>
+          ) : null}
         </div>
       </div>
     </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -10,6 +10,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        cinematic:
+          'bg-gradient-to-r from-primary to-[oklch(0.72_0.18_60)] text-primary-foreground shadow-lg shadow-primary/25 hover:brightness-110',
         destructive:
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
@@ -24,6 +26,7 @@ const buttonVariants = cva(
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        xl: 'h-11 rounded-full px-7 has-[>svg]:px-5',
         icon: 'size-9',
         'icon-sm': 'size-8',
         'icon-lg': 'size-10',

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/70 backdrop-blur-md transition-opacity duration-200 data-[state=closed]:opacity-0 data-[state=open]:opacity-100",
+      className,
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showClose?: boolean
+    overlayClassName?: string
+  }
+>(({ className, children, showClose = true, overlayClassName, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay className={overlayClassName} />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-white/10 bg-[oklch(0.14_0.02_248/0.95)] p-6 text-white shadow-2xl",
+        "transition-all duration-200 data-[state=closed]:scale-[0.98] data-[state=closed]:opacity-0 data-[state=open]:scale-100 data-[state=open]:opacity-100",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      {showClose ? (
+        <DialogPrimitive.Close
+          className="absolute right-4 top-4 rounded-lg p-1.5 text-white/45 opacity-90 ring-offset-background transition-all hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </DialogPrimitive.Close>
+      ) : null}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-white/55", className)} {...props} />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       dockerfile: Dockerfile
     environment:
       YOUTUBE_API_KEY: ${YOUTUBE_API_KEY:-}
+      SUPADATA_API_KEY: ${SUPADATA_API_KEY:-}
       INTERNAL_SIDECAR_SECRET: ${INTERNAL_SIDECAR_SECRET:-}
     expose:
       - "8100"

--- a/docs/deploy-cloud-run.md
+++ b/docs/deploy-cloud-run.md
@@ -77,6 +77,7 @@ Register **exactly** that redirect URI in the Kroger developer console.
    | --------------------------- | ------- |
    | `GEMINI_API_KEY`            | web |
    | `YOUTUBE_API_KEY`           | web + `cravecart-youtube-mcp` |
+   | `SUPADATA_API_KEY`          | `cravecart-youtube-mcp` — recommended native-caption provider for public YouTube videos |
    | `KROGER_CLIENT_ID`          | web (+ `cravecart-kroger-mcp` if that service exists) |
    | `KROGER_CLIENT_SECRET`      | web (+ `cravecart-kroger-mcp` if that service exists) |
    | `INTERNAL_SIDECAR_SECRET`   | **`cravecart-web`** (outbound auth) + **Fly Kroger MCP** (bearer gate). Create once, e.g. `openssl rand -base64 32 \| gcloud secrets create INTERNAL_SIDECAR_SECRET --data-file=-` |
@@ -177,6 +178,7 @@ Map a domain to `cravecart-web` in Cloud Run, then update env:
 
 - `pnpm install && pnpm build` (or Docker `docker compose build web && docker compose up`).
 - Open `/api/health` and confirm sidecars respond when URLs in `.env` match your local or compose network, and **`firebaseConfigured`** is `true` when Firebase env + Admin credentials are loaded.
+- For `youtube-mcp`, `GET /health` should show **`supadataConfigured: true`** when the secret is mounted correctly.
 - Firestore rules: from repo root, `firebase deploy --only firestore:rules` (after `firebase login`), using [`.firebaserc`](../.firebaserc) / [firebase.json](../firebase.json).
 
 ## Observability
@@ -299,6 +301,7 @@ The workflow [`.github/workflows/deploy-main.yml`](../.github/workflows/deploy-m
 | `FLY_API_TOKEN` | Always. Create via **`fly tokens create`** scoped to deploy. |
 | `FIREBASE_AUTH_DOMAIN` | **Strongly recommended** if your Firebase Console **authDomain** is not **`{projectId}.firebaseapp.com`** (common when project id and hosting domain disagree). Passed to Cloud Build as **`_FIREBASE_AUTH_DOMAIN`** so **`/api/firebase-public-config`** serves the correct Auth host. |
 | `FIREBASE_PROJECT_ID` | Optional. If set, passed as **`_FIREBASE_PROJECT_ID`** (otherwise **`project_id`** inside **`FIREBASE_SERVICE_ACCOUNT_JSON`** is enough). |
+| `SUPADATA_API_KEY` | Optional mirror only. The deploy workflow does **not** read this secret directly; runtime still mounts `SUPADATA_API_KEY` from **GCP Secret Manager** into `cravecart-youtube-mcp`. Keeping a repo secret copy can help operators track the current value inventory in one place. |
 | `GCP_SA_KEY` | If **`GCP_USE_WIF`** is not **`true`** — JSON key for an SA that may **submit builds** (**`roles/cloudbuild.builds.editor`** or **`roles/run.admin`** + Artifact Registry **`writer`**, plus **`roles/iam.serviceAccountUser`** on the Cloud Build / runtime principals your project expects). If you use **`deploy-fly-ci.sh`**, the same principal must **`secretAccessor`** on **`KROGER_CLIENT_ID`**, **`KROGER_CLIENT_SECRET`**, **`INTERNAL_SIDECAR_SECRET`** (optional **`KROGER_LOCATION_ID`**), matching local **`deploy-fly.ps1 -FromGcpSecretManager`** expectations. Mirrors what you already use locally for **`gcloud builds submit`**. |
 
 **Workload Identity Federation** (recommended over long-lived SA keys):
@@ -317,6 +320,8 @@ Set **`GCP_USE_WIF=true`** after following [Google’s “Configure Workload Ide
 | **Cloud Run (`cravecart-web`, MCPs)** | [`cloudbuild.yaml`](../cloudbuild.yaml) **`--set-secrets …=SECRET_NAME:latest`**. **`cravecart-web`** mounts **`FIREBASE_SERVICE_ACCOUNT_JSON`** + **`FIREBASE_WEB_API_KEY`** (and optional **`_FIREBASE_AUTH_DOMAIN`** / **`_FIREBASE_PROJECT_ID`** substitutions from GitHub). Containers receive secret payloads as env (no plaintext values in YAML). Rotate by adding Secret Manager versions; redeploy pulls **`latest`**. |
 | **Fly Kroger MCP** | [`kroger-mcp/deploy-fly-ci.sh`](../kroger-mcp/deploy-fly-ci.sh) runs **`gcloud secrets versions access`** for **`KROGER_CLIENT_*`**, **`INTERNAL_SIDECAR_SECRET`**, optionally **`KROGER_LOCATION_ID`**, then **`fly secrets import`** (non-staged) and **`fly deploy`**. **`INTERNAL_SIDECAR_SECRET`** must match **`cravecart-web`** Secret Manager (**version pinning** in CI — see troubleshooting above). |
 | **`KROGER_LOCATION_ID`** | Prefer the Cloud Build **`_KROGER_LOCATION_ID`** substitution (GitHub Actions secret **`KROGER_LOCATION_ID`**); the script falls back to **Secret Manager secret** `KROGER_LOCATION_ID` or the live **`cravecart-web`** env if present. |
+
+`SUPADATA_API_KEY` follows the same runtime pattern as the other Cloud Run-mounted secrets: Secret Manager is the source of truth, and `cloudbuild.yaml` mounts it into `cravecart-youtube-mcp`. A GitHub repo secret mirror is optional bookkeeping, not a deploy input.
 
 ### Security notes (reasonable defaults)
 

--- a/kroger-mcp/app.py
+++ b/kroger-mcp/app.py
@@ -636,6 +636,29 @@ def auth_start(x_cravecart_session: str | None = Header(default=None)) -> dict[s
     return {"authUrl": auth_url}
 
 
+@fastapi.get("/session/status")
+def session_oauth_status(x_cravecart_session: str | None = Header(default=None)) -> dict[str, Any]:
+    session_id = require_session(x_cravecart_session)
+    return {
+        "ok": True,
+        "configured": is_configured(),
+        "authenticated": bool(get_user_token(session_id)),
+    }
+
+
+@fastapi.post("/session/clear")
+def session_clear(x_cravecart_session: str | None = Header(default=None)) -> dict[str, Any]:
+    """Remove OAuth + cart state file for this browser session (disconnect)."""
+    session_id = require_session(x_cravecart_session)
+    path = session_path(session_id)
+    if path.is_file():
+        try:
+            path.unlink()
+        except OSError as exc:  # pragma: no cover - rare fs issues
+            logger.warning("session_clear_unlink_failed: %s", exc)
+    return {"ok": True}
+
+
 @fastapi.post("/auth/callback")
 def auth_callback(payload: AuthCallbackPayload, x_cravecart_session: str | None = Header(default=None)) -> dict[str, Any]:
     session_id = require_session(x_cravecart_session)

--- a/lib/agent/gemini.ts
+++ b/lib/agent/gemini.ts
@@ -37,6 +37,7 @@ export function getAgentSystemPrompt(domainHint: string): string {
     "Prefer a single, well-explained recipe video over compilations or multi-recipe roundups when the user wants ingredients for one dish.",
     "When the user asks for a video, try up to five likely candidates to find one with a transcript first.",
     "Use the transcript plus the video description as the source of truth for your answer and for downstream recipe or shopping steps.",
+    "If a tool says transcriptStatus is blocked, do not claim the video has no transcript or no captions. Explain that YouTube blocked transcript retrieval from the server, so the video may still have CC on YouTube even though CraveCart could not fetch it.",
     "If none of the first five likely candidates have a transcript, use the most relevant video anyway and infer ingredients from the title and description.",
     "If you already have saved video context from a previous turn, answer from that saved context instead of re-fetching the same video unless the user explicitly asks for a new search.",
     "If a transcript is unavailable but you still have the title and description, explain that the answer is inferred from the available video metadata instead of refusing.",

--- a/lib/agent/gemini.ts
+++ b/lib/agent/gemini.ts
@@ -38,6 +38,8 @@ export function getAgentSystemPrompt(domainHint: string): string {
     "When the user asks for a video, try up to five likely candidates to find one with a transcript first.",
     "Use the transcript plus the video description as the source of truth for your answer and for downstream recipe or shopping steps.",
     "If a tool says transcriptStatus is blocked, do not claim the video has no transcript or no captions. Explain that YouTube blocked transcript retrieval from the server, so the video may still have CC on YouTube even though CraveCart could not fetch it.",
+    "Never claim a recipe, ingredient list, or instructions came from a transcript unless the saved recipe source is youtube_transcript.",
+    "If the saved recipe source is video_metadata or fallback_recipe, say that plainly instead of implying transcript access.",
     "If none of the first five likely candidates have a transcript, use the most relevant video anyway and infer ingredients from the title and description.",
     "If you already have saved video context from a previous turn, answer from that saved context instead of re-fetching the same video unless the user explicitly asks for a new search.",
     "If a transcript is unavailable but you still have the title and description, explain that the answer is inferred from the available video metadata instead of refusing.",

--- a/lib/agent/intent.ts
+++ b/lib/agent/intent.ts
@@ -37,6 +37,10 @@ const CARRYOVER_CONTEXT_PATTERNS = [
   /\bhow do i make it\b/i,
   /\bwhat('?s| is)\s+in\s+it\b/i,
   /\bwhat ingredients\b/i,
+  /^\s*transcript\??\s*$/i,
+  /\bwhat does\b.{0,24}\btranscript\b.{0,24}\bsay\b/i,
+  /\bwhat('?s| is)\s+the\s+transcript\b/i,
+  /\bshow\b.{0,12}\b(transcript|captions?|cc)\b/i,
 ]
 const CART_STATUS_PATTERNS = [
   /\bdid you\b.{0,24}\b(buy|add|get)\b.{0,24}\ball\b.{0,24}\bingredients\b/i,
@@ -52,6 +56,11 @@ const VIDEO_CONTEXT_FOLLOWUP_PATTERNS = [
   /\bwhat ingredients\b/i,
   /\btell me more\b.{0,20}\b(video|recipe|it)\b/i,
   /\bhow does\b.{0,20}\bit\b.{0,20}\bwork\b/i,
+  /^\s*transcript\??\s*$/i,
+  /\bwhat does\b.{0,24}\btranscript\b.{0,24}\bsay\b/i,
+  /\bwhat('?s| is)\s+the\s+transcript\b/i,
+  /\bshow\b.{0,12}\b(transcript|captions?|cc)\b/i,
+  /\bdoes\b.{0,16}\bit\b.{0,16}\bhave\b.{0,16}\b(transcript|captions?|cc)\b/i,
 ]
 
 export function getLatestUserMessage(messages: ChatMessage[]): string {

--- a/lib/agent/runAgentTurn.ts
+++ b/lib/agent/runAgentTurn.ts
@@ -506,7 +506,7 @@ function buildSavedVideoContextPrompt(input: {
   transcriptAvailable: boolean
   transcriptStatus?: "available" | "unavailable" | "blocked" | "error"
   transcriptMessage?: string
-  recipeSource: "youtube_transcript" | "fallback_recipe" | "none"
+  recipeSource: "youtube_transcript" | "fallback_recipe" | "video_metadata" | "none"
   recipeText: string
 }) {
   const transcriptStatusLine =
@@ -520,6 +520,14 @@ function buildSavedVideoContextPrompt(input: {
         ? "The transcript could not be retrieved right now. Answer from the saved title and description context, and clearly say the answer is inferred from the available video metadata."
         : "The transcript was unavailable. Infer the answer from the saved video title and description context, and say that it is inferred from the available video metadata."
     : "Use the saved transcript and description context directly."
+  const recipeSourceGuidance =
+    input.recipeSource === "youtube_transcript"
+      ? "The earlier recipe context came from the saved YouTube transcript plus the video metadata."
+      : input.recipeSource === "video_metadata"
+        ? "The earlier recipe context came from the video title and description only. Do not say it came from the transcript."
+        : input.recipeSource === "fallback_recipe"
+          ? "The earlier recipe context came from CraveCart's fallback recipe, not from the YouTube transcript."
+          : "The earlier recipe source is unknown. Do not claim it came from the transcript."
 
   return [
     "Server note: answer from the saved video context already loaded in this session. Do not call any tools.",
@@ -530,7 +538,9 @@ function buildSavedVideoContextPrompt(input: {
     input.transcriptMessage ? `Transcript note: ${input.transcriptMessage}` : "",
     `Saved recipe source: ${input.recipeSource}.`,
     transcriptGuidance,
+    recipeSourceGuidance,
     `Saved context:\n${input.recipeText.slice(0, 5000)}`,
+    "If the user asks about the transcript, answer with the actual transcript status first, then explain what source the earlier recipe came from.",
     "Give a concise, direct answer to the user's question.",
   ].join("\n\n")
 }

--- a/lib/agent/runAgentTurn.ts
+++ b/lib/agent/runAgentTurn.ts
@@ -63,6 +63,8 @@ export async function runAgentTurn(input: RunAgentTurnInput, sink: EventSink = (
             title: savedArtifact.video.title,
             channel: savedArtifact.video.channel,
             transcriptAvailable: savedArtifact.transcriptAvailable,
+            transcriptStatus: savedArtifact.transcriptStatus,
+            transcriptMessage: savedArtifact.transcriptMessage,
             recipeSource: savedArtifact.recipeSource,
             recipeText: toolRuntime.getLatestRecipeText() ?? "",
           }),
@@ -502,18 +504,32 @@ function buildSavedVideoContextPrompt(input: {
   title: string
   channel: string
   transcriptAvailable: boolean
+  transcriptStatus?: "available" | "unavailable" | "blocked" | "error"
+  transcriptMessage?: string
   recipeSource: "youtube_transcript" | "fallback_recipe" | "none"
   recipeText: string
 }) {
+  const transcriptStatusLine =
+    input.transcriptStatus && input.transcriptStatus !== "available"
+      ? `Transcript fetch status: ${input.transcriptStatus}.`
+      : ""
+  const transcriptGuidance = !input.transcriptAvailable
+    ? input.transcriptStatus === "blocked"
+      ? "The video may still have captions on YouTube, but transcript retrieval from the server was blocked. Do not say the video has no captions. Answer from the saved title and description context, and clearly say the answer is inferred because the server could not fetch the transcript."
+      : input.transcriptStatus === "error"
+        ? "The transcript could not be retrieved right now. Answer from the saved title and description context, and clearly say the answer is inferred from the available video metadata."
+        : "The transcript was unavailable. Infer the answer from the saved video title and description context, and say that it is inferred from the available video metadata."
+    : "Use the saved transcript and description context directly."
+
   return [
     "Server note: answer from the saved video context already loaded in this session. Do not call any tools.",
     `User follow-up: ${input.userMessage}`,
     `Current video: ${input.title} by ${input.channel}.`,
     `Transcript available: ${input.transcriptAvailable ? "yes" : "no"}.`,
+    transcriptStatusLine,
+    input.transcriptMessage ? `Transcript note: ${input.transcriptMessage}` : "",
     `Saved recipe source: ${input.recipeSource}.`,
-    !input.transcriptAvailable
-      ? "The transcript was unavailable. Infer the answer from the saved video title and description context, and say that it is inferred from the available video metadata."
-      : "Use the saved transcript and description context directly.",
+    transcriptGuidance,
     `Saved context:\n${input.recipeText.slice(0, 5000)}`,
     "Give a concise, direct answer to the user's question.",
   ].join("\n\n")

--- a/lib/agent/toolRuntime.ts
+++ b/lib/agent/toolRuntime.ts
@@ -50,6 +50,8 @@ interface YoutubeSearchResult {
     durationSeconds: number | null
     score: number
     transcriptAvailable?: boolean
+    transcriptStatus?: "available" | "unavailable" | "blocked" | "error"
+    transcriptMessage?: string
   }>
 }
 
@@ -63,6 +65,7 @@ interface YoutubeContextResult {
     description: string
   }
   transcriptAvailable: boolean
+  transcriptStatus?: "available" | "unavailable" | "blocked" | "error"
   transcript?: string
   transcriptMessage?: string
 }
@@ -528,10 +531,16 @@ export class AgentToolRuntime {
 
     const first = result.data.videos[0]
     const transcriptBackedCount = result.data.videos.filter((video) => video.transcriptAvailable).length
+    const transcriptSummary =
+      transcriptBackedCount === 0
+        ? ""
+        : transcriptBackedCount === result.data.videos.length
+          ? ", all transcript-backed"
+          : `, ${transcriptBackedCount} transcript-backed`
     return {
       response: result.data as unknown as Record<string, unknown>,
       summary: first
-        ? `Found ${result.data.videos.length} YouTube candidates${transcriptBackedCount > 0 ? `, all transcript-backed` : ""}. Top result: ${first.title}.`
+        ? `Found ${result.data.videos.length} YouTube candidates${transcriptSummary}. Top result: ${first.title}.`
         : "No YouTube videos found.",
     }
   }
@@ -551,7 +560,11 @@ export class AgentToolRuntime {
       recipeSource = "youtube_transcript"
       recipeText = buildVideoRecipeText(result.data.video, result.data.transcript)
     } else {
-      recipeText = buildVideoDescriptionContext(result.data.video)
+      recipeText = buildVideoDescriptionContext(
+        result.data.video,
+        result.data.transcriptStatus,
+        result.data.transcriptMessage,
+      )
     }
 
     if (!result.data.transcriptAvailable && dishHint) {
@@ -572,8 +585,17 @@ export class AgentToolRuntime {
     this.latestFallbackStructuredRecipe = fallbackStructuredRecipe
     this.latestExtractedRecipe = null
 
+    const transcriptStatus = result.data.transcriptStatus
     const summary = recipeSource === "youtube_transcript"
       ? `Transcript available for ${result.data.video.title}.`
+      : transcriptStatus === "blocked"
+        ? recipeSource === "fallback_recipe"
+          ? `YouTube temporarily blocked transcript retrieval for ${result.data.video.title}; using the fallback recipe for ${dishHint}.`
+          : `YouTube temporarily blocked transcript retrieval for ${result.data.video.title}; using the video title and description instead.`
+      : transcriptStatus === "error"
+        ? recipeSource === "fallback_recipe"
+          ? `Could not retrieve the transcript for ${result.data.video.title} right now; using the fallback recipe for ${dishHint}.`
+          : `Could not retrieve the transcript for ${result.data.video.title} right now; using the video title and description instead.`
       : recipeSource === "fallback_recipe"
         ? `Transcript unavailable for ${result.data.video.title}; using the fallback recipe for ${dishHint}.`
         : `Transcript unavailable for ${result.data.video.title}; inferring from the video title and description.`
@@ -586,6 +608,8 @@ export class AgentToolRuntime {
         channel: result.data.video.channel,
       },
       transcriptAvailable: result.data.transcriptAvailable,
+      transcriptStatus: result.data.transcriptStatus,
+      transcriptMessage: result.data.transcriptMessage,
       recipeSource,
       summary: recipeText?.slice(0, 280) ?? result.data.video.description ?? summary,
     }
@@ -1140,12 +1164,23 @@ function buildVideoDescriptionContext(
     channel: string
     description?: string
   },
+  transcriptStatus?: "available" | "unavailable" | "blocked" | "error",
+  transcriptMessage?: string,
 ) {
+  const transcriptNote =
+    transcriptStatus === "blocked"
+      ? "Transcript retrieval was temporarily blocked by YouTube from the server side. The video may still have captions on YouTube, so infer the most likely recipe ingredients and instructions from the title and description only."
+      : transcriptStatus === "error"
+        ? "Transcript retrieval failed for this video right now. Infer the most likely recipe ingredients and instructions from the title and description only."
+      : transcriptMessage?.trim()
+        ? `${transcriptMessage.trim()} Infer the most likely recipe ingredients and instructions from the title and description only.`
+        : "Transcript unavailable. Infer the most likely recipe ingredients and instructions from the title and description only."
+
   return [
     `Video title: ${video.title}`,
     video.channel ? `Channel: ${video.channel}` : "",
     video.description?.trim() ? `Video description:\n${video.description.trim()}` : "",
-    "Transcript unavailable. Infer the most likely recipe ingredients and instructions from the title and description only.",
+    transcriptNote,
   ]
     .filter(Boolean)
     .join("\n\n")

--- a/lib/agent/toolRuntime.ts
+++ b/lib/agent/toolRuntime.ts
@@ -264,7 +264,7 @@ export class AgentToolRuntime {
           type: "object",
           properties: {
             dish: { type: "string" },
-            recipeSource: { type: "string", enum: ["youtube_transcript", "fallback_recipe", "none"] },
+            recipeSource: { type: "string", enum: ["youtube_transcript", "fallback_recipe", "video_metadata", "none"] },
             unmatchedIngredients: {
               type: "array",
               items: { type: "string" },
@@ -560,6 +560,7 @@ export class AgentToolRuntime {
       recipeSource = "youtube_transcript"
       recipeText = buildVideoRecipeText(result.data.video, result.data.transcript)
     } else {
+      recipeSource = "video_metadata"
       recipeText = buildVideoDescriptionContext(
         result.data.video,
         result.data.transcriptStatus,
@@ -952,7 +953,8 @@ export class AgentToolRuntime {
       message: status === "partial_cart_ready" ? "Some ingredients could not be matched or added." : undefined,
     }
 
-    this.latestArtifact = artifact
+    const priorVideoArtifact = this.latestArtifact?.kind === "video" ? this.latestArtifact : null
+    this.latestArtifact = priorVideoArtifact ?? artifact
     this.latestCart = artifact
     this.pendingSelections.clear()
 
@@ -1024,7 +1026,7 @@ export class AgentToolRuntime {
 }
 
 function isRecipeSourceValue(value: unknown): value is RecipeSource | "none" {
-  return value === "youtube_transcript" || value === "fallback_recipe" || value === "none"
+  return value === "youtube_transcript" || value === "fallback_recipe" || value === "video_metadata" || value === "none"
 }
 
 function isVideoMeta(

--- a/lib/api/handleCraveRequest.ts
+++ b/lib/api/handleCraveRequest.ts
@@ -42,7 +42,7 @@ export async function handleCraveRequest(input: RunCravePipelineInput, sessionId
         openCartUrl: result.cart.openCartUrl,
       },
       hiddenDetails: {
-        recipeSource: result.cart.recipeSource === "none" ? "fallback_recipe" : result.cart.recipeSource,
+        recipeSource: result.cart.recipeSource === "none" ? "video_metadata" : result.cart.recipeSource,
         unmatchedIngredients: result.cart.unmatchedIngredients,
       },
     }

--- a/lib/chat/chatHistoryPayload.ts
+++ b/lib/chat/chatHistoryPayload.ts
@@ -1,0 +1,31 @@
+import type { ChatMessage } from "@/lib/types"
+
+/** Shown to the agent when persisted history lacks assistant text so Zod/API never rejects. */
+export const EMPTY_ASSISTANT_REPLAY_FALLBACK =
+  "(Previous assistant reply missing in saved history—you can continue this thread normally.)"
+
+type ChatLike = {
+  role: ChatMessage["role"]
+  content: string
+  error?: string | null
+}
+
+/** Ensures `/api/chat` receives `content` strings that pass `.trim().min(1)`. */
+export function buildChatMessagesForAgent(msgs: ReadonlyArray<ChatLike>): ChatMessage[] {
+  return msgs.map((m) => {
+    const trimmed = typeof m.content === "string" ? m.content.replace(/\s+/g, " ").trim() : ""
+    if (trimmed.length > 0) return { role: m.role, content: trimmed }
+    if (m.role === "assistant") {
+      const err = typeof m.error === "string" ? m.error.replace(/\s+/g, " ").trim() : ""
+      return { role: "assistant", content: err.slice(0, 8000) || EMPTY_ASSISTANT_REPLAY_FALLBACK }
+    }
+    return { role: "user", content: "…" }
+  })
+}
+
+/** When loading Firestore/local history, coerce empty bubbles so persisted rounds stay valid clientside. */
+export function coerceReplayMessageContent(role: "user" | "assistant", raw: string): string {
+  const t = raw.replace(/\s+/g, " ").trim()
+  if (t.length > 0) return t
+  return role === "assistant" ? EMPTY_ASSISTANT_REPLAY_FALLBACK : "…"
+}

--- a/lib/chat/sessionTitle.ts
+++ b/lib/chat/sessionTitle.ts
@@ -1,0 +1,133 @@
+/**
+ * Chat thread titles: client persist rules + server-side normalization for `/api/chat/session-title`.
+ */
+
+/** Placeholder until Gemini (or fallback) supplies a real title. */
+export const PLACEHOLDER_CHAT_TITLE = "New chat"
+
+/** First user turn uses the current compose box; retries use the original opening message. */
+export function pickFirstUserMessageForSessionTitle(args: {
+  isFirstUserTurn: boolean
+  currentPrompt: string
+  priorMessages: ReadonlyArray<{ role: string; content: string }>
+}): string {
+  const fromHistory = args.priorMessages.find((m) => m.role === "user")?.content
+  if (args.isFirstUserTurn) {
+    const t = args.currentPrompt.replace(/\s+/g, " ").trim()
+    return t || args.currentPrompt
+  }
+  const t = (fromHistory ?? args.currentPrompt).replace(/\s+/g, " ").trim()
+  return t || args.currentPrompt
+}
+
+function effectiveStoredTitle(raw: string | undefined): string | undefined {
+  const t = raw?.replace(/\s+/g, " ").trim()
+  if (!t || t === PLACEHOLDER_CHAT_TITLE) return undefined
+  return t
+}
+
+/**
+ * Chooses the title stored after each `/api/chat` turn. Treats sidebar `"New chat"` as unset so later
+ * prompts can temporarily label the thread (and failed AI retries can resume).
+ */
+export function resolvePersistedChatTitle(args: {
+  sessionId: string
+  resolvedTitles: ReadonlyMap<string, string>
+  sessions: ReadonlyArray<{ id: string; title: string }>
+  isFirstUserTurn: boolean
+  currentPrompt: string
+}): string {
+  const fromRef = effectiveStoredTitle(args.resolvedTitles.get(args.sessionId))
+  if (fromRef) return fromRef
+  const fromSidebar = effectiveStoredTitle(args.sessions.find((s) => s.id === args.sessionId)?.title)
+  if (fromSidebar) return fromSidebar
+  if (args.isFirstUserTurn) return PLACEHOLDER_CHAT_TITLE
+  const p = args.currentPrompt.replace(/\s+/g, " ").trim()
+  if (!p) return PLACEHOLDER_CHAT_TITLE
+  return p.length > 48 ? `${p.slice(0, 45)}…` : p
+}
+
+/** Whether we should POST `/api/chat/session-title` for this thread. */
+export function needsAiChatTitle(args: {
+  sessionId: string
+  aiTitleRequested: ReadonlySet<string>
+  resolvedTitles: ReadonlyMap<string, string>
+  sessions: ReadonlyArray<{ id: string; title: string }>
+}): boolean {
+  if (args.aiTitleRequested.has(args.sessionId)) return false
+  const settled =
+    effectiveStoredTitle(args.resolvedTitles.get(args.sessionId)) ??
+    effectiveStoredTitle(args.sessions.find((s) => s.id === args.sessionId)?.title)
+  return !settled
+}
+
+export function fallbackChatTitleFromFirstMessage(raw: string): string {
+  const t = raw.replace(/\s+/g, " ").trim()
+  if (!t) return PLACEHOLDER_CHAT_TITLE
+  return t.length > 48 ? `${t.slice(0, 45)}…` : t
+}
+
+/** Model sometimes returns headings, chatter, or 1-letter junk—prefer substantive fallbacks. */
+export function pickBestGeminiTitleLine(raw: string): string {
+  const lines = raw
+    .split(/\n/)
+    .map((line) =>
+      line
+        .replace(/\s+/g, " ")
+        .trim()
+        .replace(/^["'`]+/, "")
+        .replace(/["'`]+$/, ""),
+    )
+    .filter(Boolean)
+  if (lines.length === 0) return ""
+  const stripLead = (s: string) => s.replace(/^(?:title|thread|subject)\s*:\s*/i, "").trim()
+  let best = stripLead(lines[0]!)
+  let bestScore = scoreTitleLine(best)
+  for (const line of lines) {
+    const candidate = stripLead(line)
+    const score = scoreTitleLine(candidate)
+    if (score > bestScore) {
+      best = candidate
+      bestScore = score
+    }
+  }
+  return best
+}
+
+const HAS_LETTER_OR_DIGIT = /[A-Za-z0-9\u00C0-\u024F\u0400-\u04FF\u0590-\u05FF]+/
+
+function scoreTitleLine(s: string): number {
+  if (!s.trim()) return -1
+  const words = s.split(" ").filter(Boolean)
+  let score = Math.min(s.length, 72)
+  if (words.length >= 3) score += 12
+  else if (words.length === 2) score += 6
+  if (/[#*_`>]/.test(s)) score -= 8
+  if (/^[^A-Za-z0-9\u00C0-\u024F]+/.test(s)) score -= 4
+  return score
+}
+
+export function isLikelyPoorChatTitle(candidate: string): boolean {
+  const t = candidate.replace(/\s+/g, " ").trim()
+  if (!t || t.length < 4) return true
+  if (!HAS_LETTER_OR_DIGIT.test(t)) return true // punctuation-only / bare emoji
+  const words = t.split(" ").filter(Boolean)
+  // Single ultra-short tokens ("C", "Let") — allow 4+ char single words ("Love", "טבע")
+  if (words.length === 1 && t.length <= 3) return true
+  // Truncated label ("Wheel-", "Topic:")
+  if (/[-–—:,]\s*$/u.test(t)) return true
+  // Markdown heading crumbs
+  if (/^#{1,6}\s*\w{1,3}$/.test(t)) return true
+  return false
+}
+
+export function normalizeGeminiChatTitle(raw: string | undefined, fallbackFromUser: string): string {
+  const fallback = () => fallbackChatTitleFromFirstMessage(fallbackFromUser)
+  if (!raw) return fallback()
+  const oneLine = pickBestGeminiTitleLine(raw)
+  if (!oneLine) return fallback()
+  const cleaned = oneLine.replace(/\s+/g, " ").trim().replace(/^["']|["']$/g, "")
+  if (!cleaned) return fallback()
+  const capped = cleaned.length > 56 ? `${cleaned.slice(0, 53)}…` : cleaned
+  return isLikelyPoorChatTitle(capped) ? fallback() : capped
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -26,6 +26,16 @@ export function getAppBaseUrl(): string {
   return readEnv("APP_BASE_URL", "http://localhost:3000")
 }
 
+/**
+ * `Secure` session cookies break local Docker Compose: the image sets NODE_ENV=production while APP_BASE_URL is
+ * still http://localhost — browsers refuse Secure cookies on HTTP.
+ */
+export function useSecureSessionCookies(): boolean {
+  if (process.env.NODE_ENV !== "production") return false
+  const base = getAppBaseUrl().trim().toLowerCase()
+  return base.startsWith("https://")
+}
+
 /** Mounted MCP apps use `/mcp/`; without trailing slash Starlette redirects and can downgrade to http behind proxies. */
 function normalizeMountedMcpUrl(envName: string, defaultWithoutSlash: string): string {
   const raw = readEnv(envName, defaultWithoutSlash).replace(/\/+$/u, "")

--- a/lib/firebase/clientAuth.ts
+++ b/lib/firebase/clientAuth.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { initializeApp, getApps, type FirebaseApp } from "firebase/app"
-import type { AuthError } from "firebase/auth"
+import { sendPasswordResetEmail, type Auth, type AuthError } from "firebase/auth"
 
 export type LoadedFirebaseBrowserConfig = {
   configured: true
@@ -62,7 +62,35 @@ export async function postFirebaseSessionCookie(idToken: string): Promise<{ ok: 
   return { ok: true }
 }
 
-export function mapFirebaseAuthError(err: unknown): string {
+/**
+ * Sends reset email using your app URL when allowed; falls back without `continueUrl`
+ * when Firebase rejects it (`auth/unauthorized-continue-uri` — common if **localhost**
+ * isn’t under Authentication → **Authorized domains**).
+ */
+export async function sendCravecartPasswordResetEmail(auth: Auth, email: string, appOrigin: string): Promise<void> {
+  const origin = appOrigin.replace(/\/$/, "")
+  if (!origin) {
+    await sendPasswordResetEmail(auth, email.trim())
+    return
+  }
+  try {
+    await sendPasswordResetEmail(auth, email.trim(), {
+      url: `${origin}/auth/reset-password`,
+      handleCodeInApp: false,
+    })
+  } catch (err) {
+    const code = (err as AuthError | undefined)?.code
+    if (code === "auth/unauthorized-continue-uri" || code === "auth/invalid-continue-uri") {
+      await sendPasswordResetEmail(auth, email.trim())
+      return
+    }
+    throw err
+  }
+}
+
+export type FirebaseAuthMessageContext = "signIn" | "passwordReset" | "signUp"
+
+export function mapFirebaseAuthError(err: unknown, context: FirebaseAuthMessageContext = "signIn"): string {
   const code = (err as AuthError | undefined)?.code
   switch (code) {
     case "auth/email-already-in-use":
@@ -75,15 +103,33 @@ export function mapFirebaseAuthError(err: unknown): string {
     case "auth/invalid-credential":
       return "Invalid email or password."
     case "auth/user-not-found":
-      return "Invalid email or password."
+      return context === "passwordReset"
+        ? "No account matches that email, or signup uses a different address."
+        : "Invalid email or password."
     case "auth/too-many-requests":
       return "Too many attempts. Try again shortly."
     case "auth/invalid-action-code":
     case "auth/expired-action-code":
       return "This reset link is invalid or expired. Request a new one."
+    case "auth/unauthorized-continue-uri":
+    case "auth/invalid-continue-uri":
+      return context === "passwordReset"
+        ? "Firebase rejected the reset landing URL. Under Authentication → **Authorized domains**, add `localhost` (and `127.0.0.1` if you use it). You can retry after saving."
+        : "That redirect URL isn’t authorized in Firebase Authentication → Authorized domains."
+    case "auth/operation-not-allowed":
+      return context === "passwordReset"
+        ? "Email/password reset isn’t enabled. In Firebase Console → Authentication → Sign-in method, enable **Email/Password**."
+        : "This sign-in method isn’t enabled in Firebase yet."
+    case "auth/missing-email":
+      return "Enter your email address."
+    case "auth/network-request-failed":
+      return "Network error. Check your connection and try again."
     default:
       if (typeof code === "string" && code.startsWith("auth/")) {
-        return "Sign-in failed. Please try again."
+        const short = code.replace(/^auth\//, "")
+        return context === "passwordReset"
+          ? `Could not send reset email (${short}). In Firebase Authentication, add localhost to Authorized domains if testing locally.`
+          : "Sign-in failed. Please try again."
       }
       return err instanceof Error ? err.message : "Something went wrong."
   }

--- a/lib/firebase/clientAuth.ts
+++ b/lib/firebase/clientAuth.ts
@@ -90,6 +90,13 @@ export async function sendCravecartPasswordResetEmail(auth: Auth, email: string,
 
 export type FirebaseAuthMessageContext = "signIn" | "passwordReset" | "signUp"
 
+/**
+ * Outlook/Hotmail “safe links” prefetch URLs and can consume Firebase’s single-use reset code before the user loads
+ * the page; Gmail seldom does this — same app, different inbox behavior.
+ */
+export const FIREBASE_RESET_OUTLOOK_SAFELINKS_HINT =
+  "Outlook/Hotmail often scan reset links before you open them (Safe Links), which invalidates the one-time code—copy the link from the email, paste it into the address bar, or request another reset."
+
 export function mapFirebaseAuthError(err: unknown, context: FirebaseAuthMessageContext = "signIn"): string {
   const code = (err as AuthError | undefined)?.code
   switch (code) {
@@ -110,7 +117,9 @@ export function mapFirebaseAuthError(err: unknown, context: FirebaseAuthMessageC
       return "Too many attempts. Try again shortly."
     case "auth/invalid-action-code":
     case "auth/expired-action-code":
-      return "This reset link is invalid or expired. Request a new one."
+      return context === "passwordReset"
+        ? `This reset link is invalid or expired. ${FIREBASE_RESET_OUTLOOK_SAFELINKS_HINT}`
+        : "This reset link is invalid or expired. Request a new one."
     case "auth/unauthorized-continue-uri":
     case "auth/invalid-continue-uri":
       return context === "passwordReset"

--- a/lib/kroger/KrogerClient.ts
+++ b/lib/kroger/KrogerClient.ts
@@ -1,7 +1,15 @@
 import { devLog } from "@/lib/dev"
 import { getKrogerServiceUrl } from "@/lib/env"
 import { augmentSidecarHeaders } from "@/lib/server/sidecarGatewayFetch"
-import type { CartAddOutcome, CartItemRequest, KrogerAuthCallbackResponse, KrogerAuthStartResponse, KrogerHealthResponse, KrogerProduct } from "@/lib/types"
+import type {
+  CartAddOutcome,
+  CartItemRequest,
+  KrogerAuthCallbackResponse,
+  KrogerAuthStartResponse,
+  KrogerHealthResponse,
+  KrogerProduct,
+  KrogerSessionOAuthStatus,
+} from "@/lib/types"
 
 interface KrogerClientOptions {
   sessionId?: string | null
@@ -53,6 +61,31 @@ export class KrogerClient {
     }
 
     return response.json()
+  }
+
+  /** OAuth linked for this ``X-CraveCart-Session`` (distinct from anonymous ``/health``). */
+  async getSessionOAuthStatus(): Promise<KrogerSessionOAuthStatus> {
+    const url = `${this.baseUrl}/session/status`
+    const headers = await augmentSidecarHeaders(url, this.sessionHeadersInit())
+    const response = await fetch(url, { headers, cache: "no-store" })
+
+    if (!response.ok) {
+      return { ok: false, configured: false, authenticated: false }
+    }
+
+    return response.json() as Promise<KrogerSessionOAuthStatus>
+  }
+
+  async clearRemoteSession(): Promise<void> {
+    const url = `${this.baseUrl}/session/clear`
+    const base = new Headers(this.sessionHeadersInit())
+    const headers = await augmentSidecarHeaders(url, base)
+    const response = await fetch(url, { method: "POST", headers, cache: "no-store" })
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Kroger session clear failed: ${response.status} ${text}`)
+    }
   }
 
   private async post<T>(path: string, body: Record<string, unknown>): Promise<T> {

--- a/lib/kroger/clientStartConnect.ts
+++ b/lib/kroger/clientStartConnect.ts
@@ -1,0 +1,69 @@
+/** Set when navigating away to Kroger OAuth; cleared when connection is verified or mocked. */
+export const KROGER_CONNECT_PENDING_STORAGE_KEY = "cravecart_kroger_pending" as const
+
+/** DOM event so UI can re-read localStorage (same-tab clears do not emit `storage`). */
+export const KROGER_PENDING_HANDOFF_EVENT = "cravecart:kroger-pending-handoff"
+
+function notifyKrogerPendingHandoffListeners() {
+  if (typeof window === "undefined") return
+  window.dispatchEvent(new Event(KROGER_PENDING_HANDOFF_EVENT))
+}
+
+export function markKrogerConnectRedirectPending() {
+  if (typeof window === "undefined") return
+  localStorage.setItem(KROGER_CONNECT_PENDING_STORAGE_KEY, "1")
+  notifyKrogerPendingHandoffListeners()
+}
+
+export function clearKrogerConnectRedirectPending() {
+  if (typeof window === "undefined") return
+  if (!localStorage.getItem(KROGER_CONNECT_PENDING_STORAGE_KEY)) return
+  localStorage.removeItem(KROGER_CONNECT_PENDING_STORAGE_KEY)
+  notifyKrogerPendingHandoffListeners()
+}
+
+export type KrogerStartConnectResult =
+  | { kind: "mock" }
+  | { kind: "redirect" }
+  | { kind: "unauthorized" }
+  | { kind: "error"; message?: string }
+
+/**
+ * Starts Kroger OAuth (or mock mode). On real OAuth, redirects the browser and does not return.
+ */
+export async function startKrogerConnect(): Promise<KrogerStartConnectResult> {
+  try {
+    const res = await fetch("/api/kroger/auth/start", {
+      method: "POST",
+      credentials: "same-origin",
+    })
+    const data = (await res.json()) as { mockMode?: boolean; authUrl?: string; message?: string; error?: string }
+
+    if (res.status === 401) {
+      return { kind: "unauthorized" }
+    }
+
+    if (data.mockMode) {
+      clearKrogerConnectRedirectPending()
+      localStorage.setItem("cravecart_kroger_connected", "1")
+      localStorage.setItem("cravecart_kroger_mock", "1")
+      return { kind: "mock" }
+    }
+
+    if (data.authUrl) {
+      markKrogerConnectRedirectPending()
+      window.location.assign(data.authUrl)
+      return { kind: "redirect" }
+    }
+
+    return {
+      kind: "error",
+      message: data.message ?? data.error ?? "Could not start Kroger connection.",
+    }
+  } catch (e) {
+    return {
+      kind: "error",
+      message: e instanceof Error ? e.message : "Network error.",
+    }
+  }
+}

--- a/lib/kroger/clientStartConnect.ts
+++ b/lib/kroger/clientStartConnect.ts
@@ -1,4 +1,4 @@
-/** Set when navigating away to Kroger OAuth; cleared when connection is verified or mocked. */
+/** Set when navigating away to Kroger OAuth; cleared when connection is verified. */
 export const KROGER_CONNECT_PENDING_STORAGE_KEY = "cravecart_kroger_pending" as const
 
 /** DOM event so UI can re-read localStorage (same-tab clears do not emit `storage`). */
@@ -23,13 +23,12 @@ export function clearKrogerConnectRedirectPending() {
 }
 
 export type KrogerStartConnectResult =
-  | { kind: "mock" }
   | { kind: "redirect" }
   | { kind: "unauthorized" }
   | { kind: "error"; message?: string }
 
 /**
- * Starts Kroger OAuth (or mock mode). On real OAuth, redirects the browser and does not return.
+ * Starts Kroger OAuth. On success, redirects the browser and does not return.
  */
 export async function startKrogerConnect(): Promise<KrogerStartConnectResult> {
   try {
@@ -37,17 +36,10 @@ export async function startKrogerConnect(): Promise<KrogerStartConnectResult> {
       method: "POST",
       credentials: "same-origin",
     })
-    const data = (await res.json()) as { mockMode?: boolean; authUrl?: string; message?: string; error?: string }
+    const data = (await res.json()) as { authUrl?: string; message?: string; error?: string }
 
     if (res.status === 401) {
       return { kind: "unauthorized" }
-    }
-
-    if (data.mockMode) {
-      clearKrogerConnectRedirectPending()
-      localStorage.setItem("cravecart_kroger_connected", "1")
-      localStorage.setItem("cravecart_kroger_mock", "1")
-      return { kind: "mock" }
     }
 
     if (data.authUrl) {

--- a/lib/kroger/connectPromptSession.ts
+++ b/lib/kroger/connectPromptSession.ts
@@ -1,0 +1,14 @@
+/** Session-only: user tapped "Not now" on the Kroger connect prompt; cleared when agent needs Kroger auth or manual disconnect reconnect flow. */
+export const KROGER_CONNECT_PROMPT_DISMISSED_KEY = "cravecart_kroger_connect_prompt_dismissed"
+
+export function isKrogerConnectPromptDismissed(storage: Pick<Storage, "getItem">): boolean {
+  return storage.getItem(KROGER_CONNECT_PROMPT_DISMISSED_KEY) === "1"
+}
+
+export function setKrogerConnectPromptDismissed(storage: Pick<Storage, "setItem">): void {
+  storage.setItem(KROGER_CONNECT_PROMPT_DISMISSED_KEY, "1")
+}
+
+export function clearKrogerConnectPromptDismissed(storage: Pick<Storage, "removeItem">): void {
+  storage.removeItem(KROGER_CONNECT_PROMPT_DISMISSED_KEY)
+}

--- a/lib/kroger/session.ts
+++ b/lib/kroger/session.ts
@@ -1,6 +1,8 @@
 import { cookies } from "next/headers"
 import { randomUUID } from "node:crypto"
 
+import { useSecureSessionCookies } from "@/lib/env"
+
 export const SESSION_COOKIE_NAME = "cravecart_session"
 
 export async function ensureSessionId(): Promise<string> {
@@ -12,23 +14,25 @@ export async function ensureSessionId(): Promise<string> {
   }
 
   const sessionId = randomUUID()
-  cookieStore.set(SESSION_COOKIE_NAME, sessionId, COOKIE_OPTIONS)
+  cookieStore.set(SESSION_COOKIE_NAME, sessionId, krogerSessionCookieOptions())
 
   return sessionId
 }
 
-const COOKIE_OPTIONS = {
-  httpOnly: true,
-  sameSite: "lax" as const,
-  secure: process.env.NODE_ENV === "production",
-  path: "/",
-  maxAge: 60 * 60 * 24 * 7,
+export function krogerSessionCookieOptions() {
+  return {
+    httpOnly: true as const,
+    sameSite: "lax" as const,
+    secure: useSecureSessionCookies(),
+    path: "/",
+    maxAge: 60 * 60 * 24 * 7,
+  }
 }
 
 /** Sets the Kroger MCP session cookie to an explicit id (per-user sync from Firestore). */
 export async function setKrogerSessionCookie(sessionId: string): Promise<void> {
   const cookieStore = await cookies()
-  cookieStore.set(SESSION_COOKIE_NAME, sessionId, COOKIE_OPTIONS)
+  cookieStore.set(SESSION_COOKIE_NAME, sessionId, krogerSessionCookieOptions())
 }
 
 export async function readSessionId(): Promise<string | null> {

--- a/lib/kroger/session.ts
+++ b/lib/kroger/session.ts
@@ -12,15 +12,23 @@ export async function ensureSessionId(): Promise<string> {
   }
 
   const sessionId = randomUUID()
-  cookieStore.set(SESSION_COOKIE_NAME, sessionId, {
-    httpOnly: true,
-    sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
-    path: "/",
-    maxAge: 60 * 60 * 24 * 7,
-  })
+  cookieStore.set(SESSION_COOKIE_NAME, sessionId, COOKIE_OPTIONS)
 
   return sessionId
+}
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: "lax" as const,
+  secure: process.env.NODE_ENV === "production",
+  path: "/",
+  maxAge: 60 * 60 * 24 * 7,
+}
+
+/** Sets the Kroger MCP session cookie to an explicit id (per-user sync from Firestore). */
+export async function setKrogerSessionCookie(sessionId: string): Promise<void> {
+  const cookieStore = await cookies()
+  cookieStore.set(SESSION_COOKIE_NAME, sessionId, COOKIE_OPTIONS)
 }
 
 export async function readSessionId(): Promise<string | null> {

--- a/lib/onboarding/narrative.ts
+++ b/lib/onboarding/narrative.ts
@@ -1,0 +1,25 @@
+import { Link2, Sparkles, Truck } from "lucide-react"
+
+export const ONBOARDING_STEPS = [
+  {
+    id: "capture",
+    icon: Link2,
+    title: "Tell us your diet crave or paste a recipe video",
+    body: "Sign into CraveCart first, then you can paste a craving in plain English, add nutrition goals, or drop a YouTube link.",
+    micro: "Example: \"High-protein chicken pasta under 30 minutes.\"",
+  },
+  {
+    id: "gather",
+    icon: Sparkles,
+    title: "AI gathers the recipe intel and fills your Kroger cart",
+    body: "We extract ingredients and map them to real Kroger products. That needs a quick Kroger sign-in (OAuth) — your Kroger password never passes through CraveCart.",
+    micro: "Live parser + ingredient matching + cart-ready output.",
+  },
+  {
+    id: "checkout",
+    icon: Truck,
+    title: "Sign in to Kroger once — then pickup or delivery stays on Kroger",
+    body: "After linking Kroger from the banner or prompt, checkout and payment happen on Kroger’s site — we connect your agent run to inventory and cart.",
+    micro: "Faster meal planning, less wandering aisles.",
+  },
+] as const

--- a/lib/onboarding/state.ts
+++ b/lib/onboarding/state.ts
@@ -1,0 +1,80 @@
+/** Persists after user completes/skips the product tour (and mirrored in a first-party cookie). */
+export const STORAGE_ONBOARDING_V1 = "cravecart_onboarding_v1"
+
+/** HTTP cookie name: first visit tour finished (works when only cookies are available). */
+export const COOKIE_FIRST_TOUR_DONE_V1 = "cravecart_first_tour_done_v1"
+
+/** Set after first visit to the login screen so copy can switch to “Welcome back”. */
+export const STORAGE_VISITED_V1 = "cravecart_visited_v1"
+
+const DONE = "1"
+const COOKIE_MAX_AGE_SEC = 60 * 60 * 24 * 400 // ~400 days
+
+function readCookieValue(cookieHeader: string, name: string): string | null {
+  const parts = cookieHeader.split(";")
+  for (const part of parts) {
+    const idx = part.indexOf("=")
+    if (idx === -1) continue
+    const k = part.slice(0, idx).trim()
+    if (k !== name) continue
+    return decodeURIComponent(part.slice(idx + 1).trim())
+  }
+  return null
+}
+
+export function hasCompletedOnboarding(storage: Pick<Storage, "getItem">): boolean {
+  return storage.getItem(STORAGE_ONBOARDING_V1) === DONE
+}
+
+/** True if this browser has finished the first-visit tour (localStorage and/or cookie). */
+export function hasSeenFirstVisitTour(
+  storage: Pick<Storage, "getItem">,
+  cookieDocumentOrHeader: string | null | undefined,
+): boolean {
+  if (hasCompletedOnboarding(storage)) return true
+  if (cookieDocumentOrHeader && readCookieValue(cookieDocumentOrHeader, COOKIE_FIRST_TOUR_DONE_V1) === DONE) {
+    return true
+  }
+  return false
+}
+
+function writeFirstVisitTourCookie(): void {
+  if (typeof document === "undefined") return
+  document.cookie = [
+    `${encodeURIComponent(COOKIE_FIRST_TOUR_DONE_V1)}=${encodeURIComponent(DONE)}`,
+    "Path=/",
+    `Max-Age=${COOKIE_MAX_AGE_SEC}`,
+    "SameSite=Lax",
+  ].join("; ")
+}
+
+/** Call when user finishes the tour, skips it, or OAuth redirect is about to leave the app. */
+export function markFirstVisitTourSeen(storage: Pick<Storage, "setItem">): void {
+  storage.setItem(STORAGE_ONBOARDING_V1, DONE)
+  writeFirstVisitTourCookie()
+}
+
+/** @deprecated Prefer markFirstVisitTourSeen — same localStorage write without cookie. */
+export function markOnboardingComplete(storage: Pick<Storage, "setItem">): void {
+  storage.setItem(STORAGE_ONBOARDING_V1, DONE)
+}
+
+/** Auto-show the cinematic overlay on first-ever visit (signed in or not, Kroger linked or not). */
+export function shouldShowOnboardingAuto(args: {
+  storage: Pick<Storage, "getItem">
+  /** Use `document.cookie` in the browser; optional in tests */
+  cookie?: string | null
+}): boolean {
+  return !hasSeenFirstVisitTour(args.storage, args.cookie ?? null)
+}
+
+export function isReturningVisitor(storage: Pick<Storage, "getItem">): boolean {
+  return storage.getItem(STORAGE_VISITED_V1) === DONE
+}
+
+/** Idempotent: sets visited flag the first time so the next login screen visit gets “Welcome back”. */
+export function markVisited(storage: Pick<Storage, "getItem" | "setItem">): void {
+  if (storage.getItem(STORAGE_VISITED_V1) !== DONE) {
+    storage.setItem(STORAGE_VISITED_V1, DONE)
+  }
+}

--- a/lib/server/auth/firebaseSessionCookie.ts
+++ b/lib/server/auth/firebaseSessionCookie.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers"
 
+import { useSecureSessionCookies } from "@/lib/env"
 import type { PublicUser } from "@/lib/server/auth/publicUser"
 import { firebaseAdminConfigured, getFirebaseAdminAuth } from "@/lib/server/firebase/admin"
 
@@ -12,7 +13,7 @@ export function firebaseSessionCookieOptions() {
   return {
     httpOnly: true as const,
     sameSite: "lax" as const,
-    secure: process.env.NODE_ENV === "production",
+    secure: useSecureSessionCookies(),
     path: "/",
     maxAge: Math.floor(WEEK_MS / 1000),
   }

--- a/lib/server/auth/firebaseSessionCookie.ts
+++ b/lib/server/auth/firebaseSessionCookie.ts
@@ -18,12 +18,13 @@ export function firebaseSessionCookieOptions() {
   }
 }
 
-export async function setFirebaseSessionCookieFromIdToken(idToken: string): Promise<void> {
+export async function setFirebaseSessionCookieFromIdToken(idToken: string): Promise<{ uid: string }> {
   const auth = getFirebaseAdminAuth()
-  await auth.verifyIdToken(idToken)
+  const decoded = await auth.verifyIdToken(idToken)
   const sessionCookie = await auth.createSessionCookie(idToken, { expiresIn: WEEK_MS })
   const cookieStore = await cookies()
   cookieStore.set(FIREBASE_SESSION_COOKIE, sessionCookie, firebaseSessionCookieOptions())
+  return { uid: decoded.uid }
 }
 
 export async function clearFirebaseSessionCookie(): Promise<void> {

--- a/lib/server/krogerSessionSync.ts
+++ b/lib/server/krogerSessionSync.ts
@@ -1,0 +1,27 @@
+import { randomUUID } from "node:crypto"
+
+import { readSessionId, setKrogerSessionCookie } from "@/lib/kroger/session"
+import { getKrogerMcpSessionId, setKrogerMcpSessionId } from "@/lib/server/krogerUserPrefs"
+
+/** Binds Firebase uid ↔ opaque Kroger MCP session id in Firestore and syncs httpOnly cookie. */
+export async function syncKrogerBrowserSessionForUser(uid: string): Promise<string> {
+  const stored = await getKrogerMcpSessionId(uid)
+  const cookieNow = await readSessionId()
+
+  if (stored) {
+    if (cookieNow !== stored) {
+      await setKrogerSessionCookie(stored)
+    }
+    return stored
+  }
+
+  if (cookieNow) {
+    await setKrogerMcpSessionId(uid, cookieNow)
+    return cookieNow
+  }
+
+  const fresh = randomUUID()
+  await setKrogerMcpSessionId(uid, fresh)
+  await setKrogerSessionCookie(fresh)
+  return fresh
+}

--- a/lib/server/krogerUserPrefs.ts
+++ b/lib/server/krogerUserPrefs.ts
@@ -1,0 +1,17 @@
+import { getFirebaseAdminFirestore } from "@/lib/server/firebase/admin"
+
+const COLLECTION = "cravecart_user_prefs"
+
+function docRef(userId: string) {
+  return getFirebaseAdminFirestore().collection(COLLECTION).doc(userId)
+}
+
+export async function getKrogerMcpSessionId(userId: string): Promise<string | null> {
+  const snap = await docRef(userId).get()
+  const raw = snap.data()?.krogerMcpSessionId
+  return typeof raw === "string" && raw.length > 0 ? raw : null
+}
+
+export async function setKrogerMcpSessionId(userId: string, sessionId: string): Promise<void> {
+  await docRef(userId).set({ krogerMcpSessionId: sessionId }, { merge: true })
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -198,6 +198,8 @@ export interface VideoArtifact {
     channel: string
   }
   transcriptAvailable: boolean
+  transcriptStatus?: "available" | "unavailable" | "blocked" | "error"
+  transcriptMessage?: string
   recipeSource: RecipeSource | "none"
   summary: string
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -8,7 +8,7 @@ export type IngredientCategory =
   | "beverage"
   | "other"
 
-export type RecipeSource = "youtube_transcript" | "fallback_recipe"
+export type RecipeSource = "youtube_transcript" | "fallback_recipe" | "video_metadata"
 
 export type ProgressStepId =
   | "finding_recipe"

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -163,6 +163,13 @@ export interface KrogerHealthResponse {
   authenticated?: boolean
 }
 
+/** Per-browser-session OAuth state from kroger-mcp ``GET /session/status``. */
+export interface KrogerSessionOAuthStatus {
+  ok: boolean
+  configured: boolean
+  authenticated: boolean
+}
+
 export interface KrogerAuthStartResponse {
   authUrl: string
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6001 @@
+{
+  "name": "cravecart",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cravecart",
+      "version": "0.1.0",
+      "dependencies": {
+        "@google/genai": "^1.51.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-slot": "1.2.4",
+        "@vercel/analytics": "1.6.1",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "firebase": "^12.12.1",
+        "firebase-admin": "^13.8.0",
+        "google-auth-library": "^10.6.2",
+        "lucide-react": "^0.564.0",
+        "next": "16.2.4",
+        "react": "^19",
+        "react-dom": "^19",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
+        "tailwind-merge": "^3.3.1",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.0",
+        "@types/node": "^22",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "postcss": "^8.5",
+        "tailwindcss": "^4.2.0",
+        "typescript": "5.7.3",
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "license": "MIT"
+    },
+    "node_modules/@firebase/ai": {
+      "version": "2.11.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.21",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.27",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.21",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.11",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.2",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.11",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.11",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.0"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.5",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.6.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.19",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.4",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.14.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.8",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/functions": "0.13.3",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.21",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.21",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.25",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.25",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.11",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.24",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.11",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.23",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.8.2",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/storage": "0.14.2",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@google-cloud/firestore": {
+      "version": "7.11.6",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "fast-deep-equal": "^3.1.1",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.19.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.51.0",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.4",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.31.1",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.0",
+        "@tailwindcss/oxide-darwin-x64": "4.2.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.2.0",
+        "@tailwindcss/oxide": "4.2.0",
+        "postcss": "^8.5.6",
+        "tailwindcss": "4.2.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001769",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.19.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "license": "MIT"
+    },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.12.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.11.1",
+        "@firebase/analytics": "0.10.21",
+        "@firebase/analytics-compat": "0.2.27",
+        "@firebase/app": "0.14.11",
+        "@firebase/app-check": "0.11.2",
+        "@firebase/app-check-compat": "0.4.2",
+        "@firebase/app-compat": "0.5.11",
+        "@firebase/app-types": "0.9.4",
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-compat": "0.6.5",
+        "@firebase/data-connect": "0.6.0",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-compat": "2.1.3",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-compat": "0.4.8",
+        "@firebase/functions": "0.13.3",
+        "@firebase/functions-compat": "0.4.3",
+        "@firebase/installations": "0.6.21",
+        "@firebase/installations-compat": "0.2.21",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/messaging-compat": "0.2.25",
+        "@firebase/performance": "0.7.11",
+        "@firebase/performance-compat": "0.2.24",
+        "@firebase/remote-config": "0.8.2",
+        "@firebase/remote-config-compat": "0.2.23",
+        "@firebase/storage": "0.14.2",
+        "@firebase/storage-compat": "0.4.2",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/firebase-admin": {
+      "version": "13.8.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "farmhash-modern": "^1.1.0",
+        "fast-deep-equal": "^3.1.1",
+        "google-auth-library": "^10.6.1",
+        "jsonwebtoken": "^9.0.0",
+        "jwks-rsa": "^3.1.0",
+        "node-forge": "^1.4.0",
+        "uuid": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.19.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/uuid": {
+      "version": "11.1.1",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.5",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "7.1.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gaxios": {
+      "version": "7.1.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "4.6.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
+        "@types/long": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "duplexify": "^4.0.0",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/google-gax/node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/google-gax/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-gax/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.16",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "license": "ISC"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/jose": {
+      "version": "4.15.9",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.31.1",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.31.1",
+        "lightningcss-darwin-arm64": "1.31.1",
+        "lightningcss-darwin-x64": "1.31.1",
+        "lightningcss-freebsd-x64": "1.31.1",
+        "lightningcss-linux-arm-gnueabihf": "1.31.1",
+        "lightningcss-linux-arm64-gnu": "1.31.1",
+        "lightningcss-linux-arm64-musl": "1.31.1",
+        "lightningcss-linux-x64-gnu": "1.31.1",
+        "lightningcss-linux-x64-musl": "1.31.1",
+        "lightningcss-win32-arm64-msvc": "1.31.1",
+        "lightningcss-win32-x64-msvc": "1.31.1"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.31.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/limiter": {
+      "version": "1.1.5"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "license": "Apache-2.0"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.564.0",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.4",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/proto3-json-serializer": {
+      "version": "2.0.2",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/tsconfck": {
+      "version": "3.1.6",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@google/genai": "^1.51.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "1.2.4",
     "@vercel/analytics": "1.6.1",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@3.25.76)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot':
         specifier: 1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
@@ -775,6 +778,9 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -784,8 +790,167 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1176,6 +1341,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   arrify@2.0.1:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
@@ -1342,6 +1511,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -1533,6 +1705,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2156,6 +2332,36 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -2410,6 +2616,26 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3272,8 +3498,111 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -3281,6 +3610,40 @@ snapshots:
   '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
@@ -3579,6 +3942,10 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   arrify@2.0.1:
     optional: true
 
@@ -3720,6 +4087,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -4037,6 +4406,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.3
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -4900,6 +5271,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react@19.2.4: {}
 
   readable-stream@3.6.2:
@@ -5247,6 +5645,21 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   unpipe@1.0.0: {}
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   util-deprecate@1.0.2:
     optional: true

--- a/tests/chatHistoryPayload.test.ts
+++ b/tests/chatHistoryPayload.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import {
+  EMPTY_ASSISTANT_REPLAY_FALLBACK,
+  buildChatMessagesForAgent,
+  coerceReplayMessageContent,
+} from "@/lib/chat/chatHistoryPayload"
+
+describe("buildChatMessagesForAgent", () => {
+  it("passes through non-empty messages", () => {
+    expect(buildChatMessagesForAgent([{ role: "user", content: " hello " }])).toEqual([
+      { role: "user", content: "hello" },
+    ])
+  })
+
+  it("fills assistant content from error when text is empty", () => {
+    expect(
+      buildChatMessagesForAgent([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "", error: '{"type":"error"}' },
+      ]),
+    ).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: '{"type":"error"}' },
+    ])
+  })
+
+  it("uses sentinel when assistant has no text and no error", () => {
+    expect(
+      buildChatMessagesForAgent([
+        { role: "user", content: "a" },
+        { role: "assistant", content: "   " },
+      ]),
+    ).toEqual([
+      { role: "user", content: "a" },
+      { role: "assistant", content: EMPTY_ASSISTANT_REPLAY_FALLBACK },
+    ])
+  })
+})
+
+describe("coerceReplayMessageContent", () => {
+  it("trims non-empty content", () => {
+    expect(coerceReplayMessageContent("user", "  ok  ")).toBe("ok")
+  })
+
+  it("coerces empty assistant bubbles for storage/replay", () => {
+    expect(coerceReplayMessageContent("assistant", "")).toBe(EMPTY_ASSISTANT_REPLAY_FALLBACK)
+  })
+})

--- a/tests/handleCraveRequest.test.ts
+++ b/tests/handleCraveRequest.test.ts
@@ -88,4 +88,54 @@ describe("handleCraveRequest", () => {
       authUrl: "/auth/kroger",
     })
   })
+
+  it("maps unknown cart source to video_metadata for legacy responses", async () => {
+    runAgentTurn.mockResolvedValue({
+      assistantMessage: "Your Kroger cart is ready.",
+      activity: [],
+      artifact: null,
+      needsAuth: false,
+      authUrl: null,
+      cart: {
+        kind: "cart",
+        status: "cart_ready",
+        dish: "American cheeseburger",
+        retailer: "Kroger",
+        itemsAdded: 1,
+        estimatedTotal: "$8.49",
+        items: [
+          {
+            ingredient: "ground beef",
+            selectedProduct: "Kroger Ground Beef 80/20",
+            quantity: 1,
+            unit: "package",
+            price: "$8.49",
+            upc: "123",
+          },
+        ],
+        openCartUrl: "https://www.kroger.com/cart",
+        unmatchedIngredients: [],
+        recipeSource: "none",
+        video: {
+          title: "Best American Cheeseburger",
+          url: "https://www.youtube.com/watch?v=demo",
+          channel: "Demo Chef",
+        },
+      },
+    })
+
+    const { handleCraveRequest } = await import("@/lib/api/handleCraveRequest")
+    const response = await handleCraveRequest(
+      {
+        craving: "I'm craving an American cheeseburger",
+        servings: 4,
+      },
+      "session-123",
+    )
+
+    expect(response.status).toBe("cart_ready")
+    if (response.status === "cart_ready") {
+      expect(response.hiddenDetails.recipeSource).toBe("video_metadata")
+    }
+  })
 })

--- a/tests/intentGuard.test.ts
+++ b/tests/intentGuard.test.ts
@@ -17,6 +17,8 @@ describe("agent intent guard", () => {
   it("detects follow-up turns that should reuse prior recipe context", () => {
     expect(shouldUseCarryoverContext("buy them for me")).toBe(true)
     expect(shouldUseCarryoverContext("did you buy all the ingredients")).toBe(true)
+    expect(shouldUseCarryoverContext("what does the transcript say")).toBe(true)
+    expect(shouldUseCarryoverContext("transcript?")).toBe(true)
     expect(shouldUseCarryoverContext("tell me about a new pizza video")).toBe(false)
   })
 
@@ -29,6 +31,8 @@ describe("agent intent guard", () => {
   it("detects video context follow-ups that should reuse saved context", () => {
     expect(isVideoContextFollowup("how did he make it")).toBe(true)
     expect(isVideoContextFollowup("what ingredients were in it")).toBe(true)
+    expect(isVideoContextFollowup("what does the transcript say")).toBe(true)
+    expect(isVideoContextFollowup("transcript?")).toBe(true)
     expect(isVideoContextFollowup("search for another taco video")).toBe(false)
   })
 })

--- a/tests/onboardingState.test.ts
+++ b/tests/onboardingState.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import {
+  COOKIE_FIRST_TOUR_DONE_V1,
+  STORAGE_ONBOARDING_V1,
+  STORAGE_VISITED_V1,
+  hasCompletedOnboarding,
+  hasSeenFirstVisitTour,
+  isReturningVisitor,
+  markFirstVisitTourSeen,
+  markOnboardingComplete,
+  markVisited,
+  shouldShowOnboardingAuto,
+} from "@/lib/onboarding/state"
+
+function mockStorage(initial: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(initial))
+  return {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      map.set(k, v)
+    },
+    _map: map,
+  }
+}
+
+describe("shouldShowOnboardingAuto / hasSeenFirstVisitTour", () => {
+  it("is true on first visit (no storage, no cookie)", () => {
+    const s = mockStorage()
+    expect(shouldShowOnboardingAuto({ storage: s, cookie: "" })).toBe(true)
+    expect(hasSeenFirstVisitTour(s, "")).toBe(false)
+  })
+
+  it("is false when localStorage marks tour done", () => {
+    const s = mockStorage({ [STORAGE_ONBOARDING_V1]: "1" })
+    expect(shouldShowOnboardingAuto({ storage: s, cookie: "" })).toBe(false)
+    expect(hasSeenFirstVisitTour(s, "")).toBe(true)
+  })
+
+  it("is false when first-visit cookie is set (survives LS clear)", () => {
+    const s = mockStorage()
+    const cookie = `${COOKIE_FIRST_TOUR_DONE_V1}=1`
+    expect(shouldShowOnboardingAuto({ storage: s, cookie })).toBe(false)
+    expect(hasSeenFirstVisitTour(s, cookie)).toBe(true)
+  })
+
+  it("ignores Kroger / auth — linked vs not does not change truth", () => {
+    const s = mockStorage()
+    expect(shouldShowOnboardingAuto({ storage: s, cookie: null })).toBe(true)
+    expect(shouldShowOnboardingAuto({ storage: s, cookie: "" })).toBe(true)
+  })
+})
+
+describe("markOnboardingComplete", () => {
+  it("persists completion flag", () => {
+    const s = mockStorage()
+    markOnboardingComplete(s)
+    expect(s._map.get(STORAGE_ONBOARDING_V1)).toBe("1")
+    expect(hasCompletedOnboarding(s)).toBe(true)
+  })
+})
+
+describe("markFirstVisitTourSeen", () => {
+  it("persists localStorage and sets cookie in browser", () => {
+    const s = mockStorage()
+    markFirstVisitTourSeen(s)
+    expect(s._map.get(STORAGE_ONBOARDING_V1)).toBe("1")
+    if (typeof document !== "undefined") {
+      expect(document.cookie).toContain(COOKIE_FIRST_TOUR_DONE_V1)
+    }
+  })
+})
+
+describe("markVisited / isReturningVisitor", () => {
+  it("first visit is not returning", () => {
+    const s = mockStorage()
+    expect(isReturningVisitor(s)).toBe(false)
+    markVisited(s)
+    expect(isReturningVisitor(s)).toBe(true)
+  })
+
+  it("markVisited is idempotent", () => {
+    const s = mockStorage()
+    markVisited(s)
+    markVisited(s)
+    expect(s._map.get(STORAGE_VISITED_V1)).toBe("1")
+  })
+})

--- a/tests/sessionTitle.test.ts
+++ b/tests/sessionTitle.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+import {
+  PLACEHOLDER_CHAT_TITLE,
+  fallbackChatTitleFromFirstMessage,
+  isLikelyPoorChatTitle,
+  needsAiChatTitle,
+  normalizeGeminiChatTitle,
+  pickBestGeminiTitleLine,
+  pickFirstUserMessageForSessionTitle,
+  resolvePersistedChatTitle,
+} from "@/lib/chat/sessionTitle"
+
+describe("resolvePersistedChatTitle", () => {
+  const sid = "session-1"
+
+  it("uses resolved ref over sidebar when both exist", () => {
+    expect(
+      resolvePersistedChatTitle({
+        sessionId: sid,
+        resolvedTitles: new Map([[sid, "From Gemini"]]),
+        sessions: [{ id: sid, title: "Sidebar old" }],
+        isFirstUserTurn: false,
+        currentPrompt: "Second message text",
+      }),
+    ).toBe("From Gemini")
+  })
+
+  it("ignores placeholder sidebar title so a later prompt can rename the thread", () => {
+    expect(
+      resolvePersistedChatTitle({
+        sessionId: sid,
+        resolvedTitles: new Map(),
+        sessions: [{ id: sid, title: PLACEHOLDER_CHAT_TITLE }],
+        isFirstUserTurn: false,
+        currentPrompt: "Buy oat milk please",
+      }),
+    ).toBe("Buy oat milk please")
+  })
+
+  it("truncates a long prompt on non-first turns when no settled title exists", () => {
+    const long = "x".repeat(60)
+    expect(
+      resolvePersistedChatTitle({
+        sessionId: sid,
+        resolvedTitles: new Map(),
+        sessions: [{ id: sid, title: PLACEHOLDER_CHAT_TITLE }],
+        isFirstUserTurn: false,
+        currentPrompt: long,
+      }),
+    ).toBe(`${"x".repeat(45)}…`)
+  })
+
+  it("returns placeholder on first turn with no sidebar yet", () => {
+    expect(
+      resolvePersistedChatTitle({
+        sessionId: sid,
+        resolvedTitles: new Map(),
+        sessions: [],
+        isFirstUserTurn: true,
+        currentPrompt: "Craving tacos tonight",
+      }),
+    ).toBe(PLACEHOLDER_CHAT_TITLE)
+  })
+
+  it("treats resolved placeholder title as unset", () => {
+    expect(
+      resolvePersistedChatTitle({
+        sessionId: sid,
+        resolvedTitles: new Map([[sid, PLACEHOLDER_CHAT_TITLE]]),
+        sessions: [],
+        isFirstUserTurn: false,
+        currentPrompt: "Follow up msg",
+      }),
+    ).toBe("Follow up msg")
+  })
+})
+
+describe("needsAiChatTitle", () => {
+  const sid = "s"
+
+  it("needs a title while only placeholder exists in sidebar", () => {
+    expect(
+      needsAiChatTitle({
+        sessionId: sid,
+        aiTitleRequested: new Set(),
+        resolvedTitles: new Map(),
+        sessions: [{ id: sid, title: PLACEHOLDER_CHAT_TITLE }],
+      }),
+    ).toBe(true)
+  })
+
+  it("does not spam while a request is pending", () => {
+    expect(
+      needsAiChatTitle({
+        sessionId: sid,
+        aiTitleRequested: new Set([sid]),
+        resolvedTitles: new Map(),
+        sessions: [{ id: sid, title: PLACEHOLDER_CHAT_TITLE }],
+      }),
+    ).toBe(false)
+  })
+
+  it("does not need when a real sidebar title exists", () => {
+    expect(
+      needsAiChatTitle({
+        sessionId: sid,
+        aiTitleRequested: new Set(),
+        resolvedTitles: new Map(),
+        sessions: [{ id: sid, title: "Chicken ramen run" }],
+      }),
+    ).toBe(false)
+  })
+
+  it("does not need when resolved map has a settled title", () => {
+    expect(
+      needsAiChatTitle({
+        sessionId: sid,
+        aiTitleRequested: new Set(),
+        resolvedTitles: new Map([[sid, "From ref"]]),
+        sessions: [{ id: sid, title: PLACEHOLDER_CHAT_TITLE }],
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("pickFirstUserMessageForSessionTitle", () => {
+  it("uses the compose prompt on opening turn", () => {
+    expect(
+      pickFirstUserMessageForSessionTitle({
+        isFirstUserTurn: true,
+        currentPrompt: "Make lasagna ingredients",
+        priorMessages: [],
+      }),
+    ).toBe("Make lasagna ingredients")
+  })
+
+  it("uses the first user bubble on retries instead of latest prompt", () => {
+    expect(
+      pickFirstUserMessageForSessionTitle({
+        isFirstUserTurn: false,
+        currentPrompt: "Also add parmesan",
+        priorMessages: [
+          { role: "user", content: "Chicken alfredo for four" },
+          { role: "assistant", content: "ok" },
+        ],
+      }),
+    ).toBe("Chicken alfredo for four")
+  })
+})
+
+describe("fallbackChatTitleFromFirstMessage", () => {
+  it("ellipsis long lines", () => {
+    expect(fallbackChatTitleFromFirstMessage("a".repeat(60))).toBe(`${"a".repeat(45)}…`)
+  })
+
+  it("collapse whitespace", () => {
+    expect(fallbackChatTitleFromFirstMessage(" hello   world ")).toBe("hello world")
+  })
+})
+
+describe("normalizeGeminiChatTitle", () => {
+  it("falls back when model returned empty-ish text", () => {
+    expect(normalizeGeminiChatTitle(undefined, "eggs bacon")).toBe("eggs bacon")
+    expect(normalizeGeminiChatTitle("   ", "eggs bacon")).toBe("eggs bacon")
+  })
+
+  it("strips leading quotes", () => {
+    expect(normalizeGeminiChatTitle(`"Breakfast burrito groceries"`, "x")).toBe("Breakfast burrito groceries")
+  })
+
+  it("truncates long model output", () => {
+    const long = "w".repeat(80)
+    expect(normalizeGeminiChatTitle(long, "x")).toBe(`${"w".repeat(53)}…`)
+  })
+
+  it("rejects ultra-short model junk in favor of user fallback", () => {
+    expect(normalizeGeminiChatTitle("C", "i like wheels")).toBe("i like wheels")
+    expect(normalizeGeminiChatTitle("Let", "wheels of cheese please")).toBe("wheels of cheese please")
+    expect(normalizeGeminiChatTitle("Wheel-", "i like wheels")).toBe("i like wheels")
+  })
+
+  it("prefers a substantive line when the model echoes markdown or headers", () => {
+    const messy = "Here is a title:\nChicken Alfredo ingredients list"
+    expect(pickBestGeminiTitleLine(messy).toLowerCase()).toContain("alfredo")
+  })
+})
+
+describe("isLikelyPoorChatTitle", () => {
+  it("flags obvious garbage but allows short food words", () => {
+    expect(isLikelyPoorChatTitle("C")).toBe(true)
+    expect(isLikelyPoorChatTitle("Tacos")).toBe(false)
+    expect(isLikelyPoorChatTitle("מטבח")).toBe(false)
+  })
+})

--- a/tests/toolRuntime.test.ts
+++ b/tests/toolRuntime.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest"
+import { AgentToolRuntime } from "@/lib/agent/toolRuntime"
+import type { AgentSessionState, StoredPendingSelection } from "@/lib/agent/sessionState"
+import type { VideoArtifact } from "@/lib/types"
+
+describe("AgentToolRuntime", () => {
+  it("preserves the last video artifact after cart creation so transcript follow-ups still have source context", async () => {
+    const videoArtifact: VideoArtifact = {
+      kind: "video",
+      video: {
+        title: "Chicken Fettuccine Alfredo Recipe - Easy Dinner",
+        url: "https://www.youtube.com/watch?v=demo",
+        channel: "Natashas Kitchen",
+      },
+      transcriptAvailable: true,
+      transcriptStatus: "available",
+      transcriptMessage: undefined,
+      recipeSource: "youtube_transcript",
+      summary: "Transcript available for Chicken Fettuccine Alfredo Recipe - Easy Dinner.",
+    }
+
+    const initialState: AgentSessionState = {
+      latestArtifact: videoArtifact,
+      latestCart: null,
+      latestDish: "Chicken Fettuccine Alfredo",
+      latestRecipeSource: "youtube_transcript",
+      latestRecipeText: "Transcript-backed chicken alfredo recipe text",
+      latestFallbackStructuredRecipe: null,
+      latestExtractedRecipe: null,
+      pendingSelections: [] as StoredPendingSelection[],
+      unmatchedIngredients: [],
+      updatedAt: Date.now(),
+    }
+
+    const runtime = new AgentToolRuntime(
+      [{ role: "user", content: "buy the groceries for this recipe" }],
+      "session-tool-runtime",
+      initialState,
+    )
+
+    ;(runtime as unknown as { mcpClients: { callKrogerTool: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> } }).mcpClients = {
+      callKrogerTool: vi.fn().mockResolvedValue({
+        data: {
+          ok: true,
+          authenticated: true,
+          results: [{ upc: "123", quantity: 1, success: true }],
+          openCartUrl: "https://www.kroger.com/cart",
+        },
+      }),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+
+    await runtime.execute("add_kroger_items_to_cart", {
+      dish: "Chicken Fettuccine Alfredo",
+      recipeSource: "youtube_transcript",
+      unmatchedIngredients: [],
+      video: {
+        title: videoArtifact.video.title,
+        url: videoArtifact.video.url,
+        channel: videoArtifact.video.channel,
+      },
+      items: [
+        {
+          ingredient: "Chicken Breast",
+          upc: "123",
+          selectedProduct: "Kroger Chicken Breast",
+          quantity: 1,
+          unit: "package",
+          price: "$9.99",
+          priceValue: 9.99,
+          modality: "PICKUP",
+        },
+      ],
+    })
+
+    const nextState = runtime.createSessionState()
+
+    expect(nextState.latestArtifact?.kind).toBe("video")
+    expect(nextState.latestArtifact).toEqual(videoArtifact)
+    expect(nextState.latestCart?.kind).toBe("cart")
+    expect(nextState.latestCart?.recipeSource).toBe("youtube_transcript")
+  })
+})

--- a/youtube-mcp/app.py
+++ b/youtube-mcp/app.py
@@ -23,10 +23,14 @@ from youtube_transcript_api._errors import (
 
 SEARCH_URL = "https://www.googleapis.com/youtube/v3/search"
 VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos"
+SUPADATA_TRANSCRIPT_URL = "https://api.supadata.ai/v1/transcript"
 TRANSCRIPT_PROBE_LIMIT = 5
 TRANSCRIPT_LANGUAGES = ["en", "en-US", "en-GB"]
 TRANSCRIPT_CACHE_TTL_SECONDS = 15 * 60
 TRANSCRIPT_PROBE_CACHE_TTL_SECONDS = 10 * 60
+TRANSCRIPT_TRANSIENT_CACHE_TTL_SECONDS = 60
+SUPADATA_POLL_INTERVAL_SECONDS = 1.0
+SUPADATA_POLL_TIMEOUT_SECONDS = 30.0
 
 _transcript_cache: dict[str, tuple[float, dict[str, Any]]] = {}
 _transcript_probe_cache: dict[str, tuple[float, dict[str, Any]]] = {}
@@ -38,6 +42,10 @@ def env(name: str, fallback: str = "") -> str:
 
 def is_configured() -> bool:
     return bool(env("YOUTUBE_API_KEY"))
+
+
+def is_supadata_configured() -> bool:
+    return bool(env("SUPADATA_API_KEY"))
 
 
 def parse_iso_duration_to_seconds(value: str | None) -> int:
@@ -156,6 +164,13 @@ def cache_set(
     return payload
 
 
+def cache_ttl_for_payload(success_ttl_seconds: int, payload: dict[str, Any]) -> int:
+    status = payload.get("transcriptStatus")
+    if status in {"blocked", "error"}:
+        return TRANSCRIPT_TRANSIENT_CACHE_TTL_SECONDS
+    return success_ttl_seconds
+
+
 def build_transcript_error_payload(error: Exception) -> dict[str, Any]:
     if isinstance(error, (RequestBlocked, IpBlocked)):
         return {
@@ -196,6 +211,16 @@ def youtube_get(url: str, params: dict[str, Any]) -> dict[str, Any]:
     response = requests.get(url, params=params, timeout=30)
     response.raise_for_status()
     return response.json()
+
+
+def supadata_get(path: str = "", params: dict[str, Any] | None = None) -> requests.Response:
+    response = requests.get(
+        f"{SUPADATA_TRANSCRIPT_URL}{path}",
+        params=params or None,
+        headers={"x-api-key": env("SUPADATA_API_KEY")},
+        timeout=60,
+    )
+    return response
 
 
 def normalize_query(query: str) -> str:
@@ -327,19 +352,192 @@ def probe_transcript(video_id: str) -> dict[str, Any]:
     try:
         transcript_list = YouTubeTranscriptApi().list(video_id)
         transcript_list.find_transcript(TRANSCRIPT_LANGUAGES)
+        payload = {
+            "ok": True,
+            "transcriptAvailable": True,
+            "transcriptStatus": "available",
+        }
         return cache_set(
             _transcript_probe_cache,
             video_id,
-            TRANSCRIPT_PROBE_CACHE_TTL_SECONDS,
-            {
-                "ok": True,
-                "transcriptAvailable": True,
-                "transcriptStatus": "available",
-            },
+            cache_ttl_for_payload(TRANSCRIPT_PROBE_CACHE_TTL_SECONDS, payload),
+            payload,
         )
     except Exception as error:
         payload = build_transcript_error_payload(error)
-        return cache_set(_transcript_probe_cache, video_id, TRANSCRIPT_PROBE_CACHE_TTL_SECONDS, payload)
+        return cache_set(
+            _transcript_probe_cache,
+            video_id,
+            cache_ttl_for_payload(TRANSCRIPT_PROBE_CACHE_TTL_SECONDS, payload),
+            payload,
+        )
+
+
+def build_supadata_unavailable_payload(message: str = "Transcript unavailable for this video.") -> dict[str, Any]:
+    return {
+        "ok": False,
+        "transcriptAvailable": False,
+        "transcriptStatus": "unavailable",
+        "message": message,
+    }
+
+
+def build_supadata_error_payload(message: str) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "transcriptAvailable": False,
+        "transcriptStatus": "error",
+        "message": message,
+    }
+
+
+def build_supadata_transcript_payload(data: dict[str, Any]) -> dict[str, Any]:
+    content = data.get("content")
+
+    if isinstance(content, list):
+        text = " ".join(
+            str(chunk.get("text", "")).strip()
+            for chunk in content
+            if isinstance(chunk, dict) and chunk.get("text")
+        )
+    else:
+        text = str(content or "")
+
+    cleaned = clean_transcript(text)
+    if not cleaned:
+        return build_supadata_error_payload("Supadata returned an empty transcript.")
+
+    return {
+        "ok": True,
+        "transcriptAvailable": True,
+        "transcriptStatus": "available",
+        "wordCount": len(cleaned.split()),
+        "transcript": cleaned[:16000],
+    }
+
+
+def poll_supadata_transcript_job(job_id: str) -> dict[str, Any]:
+    deadline = time.monotonic() + SUPADATA_POLL_TIMEOUT_SECONDS
+
+    while time.monotonic() < deadline:
+        response = supadata_get(f"/{job_id}")
+        if response.status_code >= 400:
+            return build_supadata_error_payload(
+                f"Supadata transcript job failed with HTTP {response.status_code}."
+            )
+
+        data = response.json()
+        status = str(data.get("status") or "").lower()
+
+        if status == "completed":
+            result = data.get("result")
+            if isinstance(result, dict):
+                return build_supadata_transcript_payload(result)
+            return build_supadata_transcript_payload(data)
+
+        if status == "failed":
+            error_message = data.get("error")
+            if isinstance(error_message, dict):
+                error_message = error_message.get("message") or error_message.get("details")
+            return build_supadata_error_payload(
+                str(error_message or "Supadata transcript job failed.")
+            )
+
+        time.sleep(SUPADATA_POLL_INTERVAL_SECONDS)
+
+    return build_supadata_error_payload("Supadata transcript job timed out.")
+
+
+def try_fetch_supadata_transcript_payload(video_id: str) -> tuple[dict[str, Any] | None, bool]:
+    if not is_supadata_configured():
+        return None, False
+
+    response = supadata_get(
+        params={
+            "url": f"https://www.youtube.com/watch?v={video_id}",
+            "mode": "native",
+            "text": "true",
+        }
+    )
+
+    if response.status_code == 200:
+        return build_supadata_transcript_payload(response.json()), False
+
+    if response.status_code == 202:
+        job_id = str((response.json() or {}).get("jobId") or "").strip()
+        if not job_id:
+            return build_supadata_error_payload("Supadata returned an empty transcript job id."), False
+        return poll_supadata_transcript_job(job_id), False
+
+    if response.status_code == 206:
+        return build_supadata_unavailable_payload(), False
+
+    if response.status_code in {401, 403}:
+        return (
+            build_supadata_error_payload(
+                f"Supadata transcript API rejected the request with HTTP {response.status_code}."
+            ),
+            False,
+        )
+
+    if response.status_code == 404:
+        return build_supadata_unavailable_payload(), False
+
+    if response.status_code == 429:
+        return (
+            build_supadata_error_payload(
+                "Supadata transcript API rate limit exceeded. Falling back to direct YouTube retrieval."
+            ),
+            True,
+        )
+
+    return (
+        build_supadata_error_payload(
+            f"Supadata transcript API failed with HTTP {response.status_code}."
+        ),
+        True,
+    )
+
+
+def fetch_youtube_transcript_payload(video_id: str) -> dict[str, Any]:
+    try:
+        transcript = YouTubeTranscriptApi().fetch(video_id, languages=TRANSCRIPT_LANGUAGES)
+        text = " ".join(part.text for part in transcript)
+        cleaned = clean_transcript(text)
+        if not cleaned:
+            return {
+                "ok": False,
+                "transcriptAvailable": False,
+                "transcriptStatus": "error",
+                "message": "Could not retrieve the transcript right now.",
+            }
+
+        return {
+            "ok": True,
+            "transcriptAvailable": True,
+            "transcriptStatus": "available",
+            "wordCount": len(cleaned.split()),
+            "transcript": cleaned[:16000],
+        }
+    except Exception as error:
+        return build_transcript_error_payload(error)
+
+
+def merge_transcript_failures(primary: dict[str, Any], fallback: dict[str, Any]) -> dict[str, Any]:
+    primary_message = str(primary.get("message") or "").strip()
+    fallback_message = str(fallback.get("message") or "").strip()
+
+    if primary_message and fallback_message and fallback_message != primary_message:
+        message = f"{primary_message} {fallback_message}"
+    else:
+        message = primary_message or fallback_message or "Could not retrieve the transcript right now."
+
+    return {
+        "ok": False,
+        "transcriptAvailable": False,
+        "transcriptStatus": primary.get("transcriptStatus") or fallback.get("transcriptStatus") or "error",
+        "message": message,
+    }
 
 
 def fetch_transcript_payload(video_id: str) -> dict[str, Any]:
@@ -347,29 +545,25 @@ def fetch_transcript_payload(video_id: str) -> dict[str, Any]:
     if cached:
         return cached
 
-    try:
-        transcript = YouTubeTranscriptApi().fetch(video_id, languages=TRANSCRIPT_LANGUAGES)
-        text = " ".join(part.text for part in transcript)
-        cleaned = clean_transcript(text)
-        if not cleaned:
-            payload = {
-                "ok": False,
-                "transcriptAvailable": False,
-                "transcriptStatus": "error",
-                "message": "Could not retrieve the transcript right now.",
-            }
+    payload: dict[str, Any]
+    supadata_payload, can_fallback = try_fetch_supadata_transcript_payload(video_id)
+    if supadata_payload and (supadata_payload.get("ok") or not can_fallback):
+        payload = supadata_payload
+    else:
+        youtube_payload = fetch_youtube_transcript_payload(video_id)
+        if youtube_payload.get("ok"):
+            payload = youtube_payload
+        elif supadata_payload:
+            payload = merge_transcript_failures(supadata_payload, youtube_payload)
         else:
-            payload = {
-                "ok": True,
-                "transcriptAvailable": True,
-                "transcriptStatus": "available",
-                "wordCount": len(cleaned.split()),
-                "transcript": cleaned[:16000],
-            }
-    except Exception as error:
-        payload = build_transcript_error_payload(error)
+            payload = youtube_payload
 
-    return cache_set(_transcript_cache, video_id, TRANSCRIPT_CACHE_TTL_SECONDS, payload)
+    return cache_set(
+        _transcript_cache,
+        video_id,
+        cache_ttl_for_payload(TRANSCRIPT_CACHE_TTL_SECONDS, payload),
+        payload,
+    )
 
 
 def get_video_detail(video_id: str) -> dict[str, Any]:
@@ -476,6 +670,7 @@ def health() -> dict[str, Any]:
     return {
         "ok": True,
         "configured": is_configured(),
+        "supadataConfigured": is_supadata_configured(),
     }
 
 

--- a/youtube-mcp/app.py
+++ b/youtube-mcp/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html
 import os
 import re
+import time
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -12,11 +13,23 @@ from internal_gate import InternalSidecarGate
 from mcp.server.fastmcp import FastMCP
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from youtube_transcript_api import YouTubeTranscriptApi
-from youtube_transcript_api._errors import NoTranscriptFound, TranscriptsDisabled
+from youtube_transcript_api._errors import (
+    IpBlocked,
+    NoTranscriptFound,
+    RequestBlocked,
+    TranscriptsDisabled,
+    YouTubeTranscriptApiException,
+)
 
 SEARCH_URL = "https://www.googleapis.com/youtube/v3/search"
 VIDEOS_URL = "https://www.googleapis.com/youtube/v3/videos"
 TRANSCRIPT_PROBE_LIMIT = 5
+TRANSCRIPT_LANGUAGES = ["en", "en-US", "en-GB"]
+TRANSCRIPT_CACHE_TTL_SECONDS = 15 * 60
+TRANSCRIPT_PROBE_CACHE_TTL_SECONDS = 10 * 60
+
+_transcript_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+_transcript_probe_cache: dict[str, tuple[float, dict[str, Any]]] = {}
 
 
 def env(name: str, fallback: str = "") -> str:
@@ -115,6 +128,68 @@ def clean_transcript(text: str) -> str:
         cleaned = cleaned.replace(phrase, "")
 
     return cleaned.strip()
+
+
+def cache_get(
+    cache: dict[str, tuple[float, dict[str, Any]]],
+    key: str,
+) -> dict[str, Any] | None:
+    cached = cache.get(key)
+    if not cached:
+        return None
+
+    expires_at, payload = cached
+    if expires_at <= time.monotonic():
+        cache.pop(key, None)
+        return None
+
+    return dict(payload)
+
+
+def cache_set(
+    cache: dict[str, tuple[float, dict[str, Any]]],
+    key: str,
+    ttl_seconds: int,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    cache[key] = (time.monotonic() + ttl_seconds, dict(payload))
+    return payload
+
+
+def build_transcript_error_payload(error: Exception) -> dict[str, Any]:
+    if isinstance(error, (RequestBlocked, IpBlocked)):
+        return {
+            "ok": False,
+            "transcriptAvailable": False,
+            "transcriptStatus": "blocked",
+            "message": (
+                "YouTube temporarily blocked transcript retrieval for this video. "
+                "The transcript may still exist, but the server could not fetch it right now."
+            ),
+        }
+
+    if isinstance(error, (NoTranscriptFound, TranscriptsDisabled)):
+        return {
+            "ok": False,
+            "transcriptAvailable": False,
+            "transcriptStatus": "unavailable",
+            "message": "Transcript unavailable for this video.",
+        }
+
+    if isinstance(error, YouTubeTranscriptApiException):
+        return {
+            "ok": False,
+            "transcriptAvailable": False,
+            "transcriptStatus": "error",
+            "message": "Could not retrieve the transcript right now.",
+        }
+
+    return {
+        "ok": False,
+        "transcriptAvailable": False,
+        "transcriptStatus": "error",
+        "message": "Could not retrieve the transcript right now.",
+    }
 
 
 def youtube_get(url: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -216,11 +291,16 @@ def search_videos(query: str, max_results: int) -> list[dict[str, Any]]:
     top_candidates = videos[: min(len(videos), TRANSCRIPT_PROBE_LIMIT)]
 
     for video in top_candidates:
-        transcript_available = has_transcript(video["videoId"])
+        transcript_probe = probe_transcript(video["videoId"])
+        transcript_available = bool(transcript_probe.get("transcriptAvailable"))
         video["transcriptAvailable"] = transcript_available
+        if transcript_probe.get("transcriptStatus"):
+            video["transcriptStatus"] = transcript_probe["transcriptStatus"]
+        if transcript_probe.get("message"):
+            video["transcriptMessage"] = transcript_probe["message"]
         if transcript_available:
             video["score"] += 12
-        else:
+        elif transcript_probe.get("transcriptStatus") == "unavailable":
             video["score"] -= 2
 
     transcript_backed = [video for video in top_candidates if video.get("transcriptAvailable")]
@@ -239,18 +319,57 @@ def search_videos(query: str, max_results: int) -> list[dict[str, Any]]:
     return videos[: max(1, min(max_results, 5))]
 
 
-def fetch_transcript(video_id: str) -> str | None:
-    transcript = YouTubeTranscriptApi().fetch(video_id, languages=["en", "en-US", "en-GB"])
-    text = " ".join(part.text for part in transcript)
-    cleaned = clean_transcript(text)
-    return cleaned or None
+def probe_transcript(video_id: str) -> dict[str, Any]:
+    cached = cache_get(_transcript_probe_cache, video_id)
+    if cached:
+        return cached
 
-
-def has_transcript(video_id: str) -> bool:
     try:
-        return bool(fetch_transcript(video_id))
-    except Exception:
-        return False
+        transcript_list = YouTubeTranscriptApi().list(video_id)
+        transcript_list.find_transcript(TRANSCRIPT_LANGUAGES)
+        return cache_set(
+            _transcript_probe_cache,
+            video_id,
+            TRANSCRIPT_PROBE_CACHE_TTL_SECONDS,
+            {
+                "ok": True,
+                "transcriptAvailable": True,
+                "transcriptStatus": "available",
+            },
+        )
+    except Exception as error:
+        payload = build_transcript_error_payload(error)
+        return cache_set(_transcript_probe_cache, video_id, TRANSCRIPT_PROBE_CACHE_TTL_SECONDS, payload)
+
+
+def fetch_transcript_payload(video_id: str) -> dict[str, Any]:
+    cached = cache_get(_transcript_cache, video_id)
+    if cached:
+        return cached
+
+    try:
+        transcript = YouTubeTranscriptApi().fetch(video_id, languages=TRANSCRIPT_LANGUAGES)
+        text = " ".join(part.text for part in transcript)
+        cleaned = clean_transcript(text)
+        if not cleaned:
+            payload = {
+                "ok": False,
+                "transcriptAvailable": False,
+                "transcriptStatus": "error",
+                "message": "Could not retrieve the transcript right now.",
+            }
+        else:
+            payload = {
+                "ok": True,
+                "transcriptAvailable": True,
+                "transcriptStatus": "available",
+                "wordCount": len(cleaned.split()),
+                "transcript": cleaned[:16000],
+            }
+    except Exception as error:
+        payload = build_transcript_error_payload(error)
+
+    return cache_set(_transcript_cache, video_id, TRANSCRIPT_CACHE_TTL_SECONDS, payload)
 
 
 def get_video_detail(video_id: str) -> dict[str, Any]:
@@ -311,21 +430,7 @@ def search_youtube_videos(query: str, max_results: int = 5) -> dict[str, Any]:
 
 @mcp.tool()
 def get_video_transcript(video_id: str) -> dict[str, Any]:
-    try:
-        transcript = fetch_transcript(video_id)
-        if not transcript:
-            return {"ok": False, "transcriptAvailable": False, "message": "Transcript unavailable."}
-
-        return {
-            "ok": True,
-            "transcriptAvailable": True,
-            "wordCount": len(transcript.split()),
-            "transcript": transcript[:16000],
-        }
-    except (NoTranscriptFound, TranscriptsDisabled):
-        return {"ok": False, "transcriptAvailable": False, "message": "Transcript unavailable."}
-    except Exception:
-        return {"ok": False, "transcriptAvailable": False, "message": "Transcript unavailable."}
+    return fetch_transcript_payload(video_id)
 
 
 @mcp.tool()
@@ -337,6 +442,7 @@ def get_video_context(video_id: str) -> dict[str, Any]:
         "ok": True,
         "video": video,
         "transcriptAvailable": bool(transcript_payload.get("transcriptAvailable")),
+        "transcriptStatus": transcript_payload.get("transcriptStatus"),
         "transcript": transcript_payload.get("transcript"),
         "wordCount": transcript_payload.get("wordCount"),
         "transcriptMessage": transcript_payload.get("message"),


### PR DESCRIPTION
Closes #10

### Kroger and Firebase user
- Firestore collection `cravecart_user_prefs` (doc id = Firebase uid) stores `krogerMcpSessionId`.
- After login (`POST /api/auth/session`), and on chat, crave, and Kroger API routes we run `syncKrogerBrowserSessionForUser`: set `cravecart_session` cookie to match Firestore, or create+persist an id first.

### Connect / disconnect
- `GET /api/kroger/status` syncs the session and reports OAuth linked vs not.
- `POST /api/kroger/disconnect` clears MCP session file and rotates prefs + cookie.
- kroger-mcp: `GET /session/status`, `POST /session/clear`.
- `POST /api/kroger/auth/start` requires Firebase sign-in (401 otherwise).

### Chat titles
- First turn: persist placeholder title "New chat", then Gemini via `POST /api/chat/session-title` from first user message, then re-save with AI title.
- Later turns reuse the resolved title instead of overwriting with the latest message.
